### PR TITLE
Use repository context for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -59,10 +59,11 @@ jobs:
         id: conflict-check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           # Get detailed PR info including mergeable state
-          PR_DATA=$(gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus)
+          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json mergeable,mergeStateStatus)
           MERGEABLE=$(echo "$PR_DATA" | jq -r '.mergeable')
           MERGE_STATE=$(echo "$PR_DATA" | jq -r '.mergeStateStatus')
 
@@ -79,27 +80,30 @@ jobs:
         if: steps.conflict-check.outputs.has_conflict == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           echo "Merge conflict detected. Requesting Dependabot to rebase..."
-          gh pr comment "$PR_NUMBER" --body "@dependabot rebase"
+          gh pr comment "$PR_NUMBER" --repo "$GH_REPO" --body "@dependabot rebase"
           echo "::warning::Merge conflict detected. Requested @dependabot rebase."
           exit 0
 
       - name: Approve Pull Request
         if: steps.conflict-check.outputs.has_conflict != 'true'
         env:
-          PR_URL: ${{ steps.pr.outputs.url }}
           GH_TOKEN: ${{ secrets.CICDBOT_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          echo "Approving PR: $PR_URL"
-          gh pr review "$PR_URL" --approve --body "🤖 Auto-approved by @cicdbot after CI passed"
+          echo "Approving PR #$PR_NUMBER"
+          gh pr review "$PR_NUMBER" --repo "$GH_REPO" --approve --body "🤖 Auto-approved by @cicdbot after CI passed"
 
       - name: Enable auto-merge
         if: steps.conflict-check.outputs.has_conflict != 'true'
         env:
-          PR_URL: ${{ steps.pr.outputs.url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          echo "Enabling auto-merge for PR: $PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
+          echo "Enabling auto-merge for PR #$PR_NUMBER"
+          gh pr merge "$PR_NUMBER" --repo "$GH_REPO" --auto --squash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Chore

**Intent:** Refactor the Dependabot auto-merge workflow to use explicit repository context (`GH_REPO` and `PR_NUMBER` environment variables) instead of relying on PR URLs. This improves consistency and maintainability of GitHub CLI commands across all workflow steps.

### 🧭 Reviewer Guide

**Entry Point:** `.github/workflows/dependabot-merge.yml` - Focus on the "Check for merge conflicts", "Request rebase if conflicts exist", "Approve Pull Request", and "Enable auto-merge" steps to verify the systematic replacement of `PR_URL` references with `PR_NUMBER` and `--repo "$GH_REPO"` flags.

**Complexity:** Low

**Estimated Review Time:** ~10 minutes

**Sensitive Areas:** None - changes are limited to GitHub Actions workflow configuration with no functional impact to application code or CI/CD behavior.

### ⚠️ Risk Assessment

- **Breaking Changes:** No - modifications maintain existing workflow behavior while improving code clarity. The refactoring from URL-based references to number-based references with explicit repository context is functionally equivalent.

- **Migrations/State:** None required - this is a configuration-only change that does not affect data, system state, or deployment. The removal of the unused "Dependabot metadata" step (which fetched but never used metadata) simplifies the workflow without impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->