### PR TITLE
cron provides its own type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/cron": "^2.4.3",
         "@types/jest": "^30.0.0",
         "@types/node": "^25",
         "@types/react": "^19",
@@ -4790,17 +4789,6 @@
       "peer": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cron": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.4.3.tgz",
-      "integrity": "sha512-ViRBkoZD9Rk0hGeMdd2GHGaOaZuH9mDmwsE5/Zo53Ftwcvh7h9VJc8lIt2wdgEwS4EW5lbtTX6vlE0idCLPOyA==",
-      "deprecated": "This is a stub types definition. cron provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cron": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/better-sqlite3": "^7.6.13",
-    "@types/cron": "^2.4.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^25",
     "@types/react": "^19",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Chore

**Intent:** Remove the redundant `@types/cron` development dependency from `package.json`. The `cron` package (v4.4.0+) now provides built-in TypeScript type definitions, eliminating the need for a separate type package.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

Start with the `package.json` file to review the removal of `@types/cron` from devDependencies. This is the only file modified in this PR. The `cron` package itself remains as a production dependency since it is actively used by `lib/services/SchedulerService.ts` for scheduling background jobs.

#### Sensitive Areas

No sensitive areas - this is a dependency cleanup with no code logic changes. The codebase already imports `CronJob` from `'cron'` in `lib/services/SchedulerService.ts`, and TypeScript will automatically resolve type definitions from the package itself rather than from a separate `@types` package.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->