### PR TITLE
Update BillService tests for bill ordering and filters

### DIFF
--- a/lib/services/BillService.test.ts
+++ b/lib/services/BillService.test.ts
@@ -121,6 +121,37 @@ describe('BillService.getFiltered', () => {
     expect(BillService.getTagsForBills).toHaveBeenCalledWith(['bill-1', 'bill-2', 'bill-3']);
   });
 
+  it('returns active bills before paid bills when no filter provided', async () => {
+    const activeBills: BillWithTags[] = [
+      {
+        ...mockBills[0],
+        id: 'active-1',
+        status: 'pending' as const,
+        dueDate: new Date('2026-01-15'),
+      },
+    ];
+
+    const paidBills: BillWithTags[] = [
+      {
+        ...mockBills[1],
+        id: 'paid-1',
+        status: 'paid' as const,
+        dueDate: new Date('2025-12-10'),
+      },
+    ];
+
+    createSelectMock(activeBills, paidBills);
+    jest.spyOn(BillService, 'getTagsForBills').mockResolvedValue(new Map());
+
+    const result = await BillService.getFiltered({});
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('active-1');
+    expect(result[0].status).toBe('pending');
+    expect(result[1].id).toBe('paid-1');
+    expect(result[1].status).toBe('paid');
+  });
+
   it('returns only bills from specified month when month filter provided', async () => {
     const decemberBills = [mockBills[0]];
     const mockBuilder = createSelectMock(decemberBills);
@@ -261,7 +292,7 @@ describe('BillService.getFiltered', () => {
         tags: [],
       },
     ];
-    createSelectMock(paidBill);
+    createSelectMock([], paidBill);
     jest.spyOn(BillService, 'getTagsForBills').mockResolvedValue(new Map());
 
     const result = await BillService.getFiltered({ date: '2025-12-10' });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Chore

**Intent:** Enhance test coverage for `BillService.getFiltered` by adding a new test case for bill ordering behavior and adjusting existing test mocks to better reflect real-world filtering scenarios.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

Start with `lib/services/BillService.test.ts`, specifically the test at lines 124-153 titled "returns active bills before paid bills when no filter provided". This new test validates that the service correctly orders active bills before paid bills when no filters are applied. Then examine the test at lines 286-303 titled "includes paid bills when filtering by date" which demonstrates that paid bills are included in date-filtered results.

#### Sensitive Areas

- `lib/services/BillService.test.ts`: Mock construction logic in `createSelectMock` helper function (lines 70-105) which handles the dual query pattern for active and paid bills
- Test case ordering expectations: Verify that the `mockBuilder.orderBy` chain correctly handles sequential mock resolutions for both active and paid bill queries

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->