### PR TITLE
Handle fully paid one-time bills in partial payment flow

### DIFF
--- a/lib/services/PaymentService.test.ts
+++ b/lib/services/PaymentService.test.ts
@@ -211,6 +211,22 @@ describe('PaymentService', () => {
       expect(result.newAmountDue).toBe(7000);
       expect(result.newStatus).toBe('pending');
     });
+
+    it('marks one-time bill as paid when fully paid via partial payment mode', () => {
+      const bill = {
+        amount: 31126,
+        amountDue: 31126,
+        dueDate: new Date('2026-05-23'),
+        frequency: 'once' as const,
+      };
+
+      const result = PaymentService.processPayment(bill, 31126, false);
+
+      expect(result.nextDueDate).toBeNull();
+      expect(result.newAmountDue).toBe(0);
+      expect(result.newStatus).toBe('paid');
+      expect(RecurrenceService.deriveStatus).not.toHaveBeenCalled();
+    });
   });
 
   describe('edge cases', () => {

--- a/lib/services/PaymentService.ts
+++ b/lib/services/PaymentService.ts
@@ -78,6 +78,16 @@ export const PaymentService = {
 
     // Partial payment: reduce amount due, keep due date unchanged
     const newAmountDue = Math.max(0, bill.amountDue - paymentAmount);
+
+    // For one-time bills, mark as paid when fully paid off
+    if (bill.frequency === 'once' && newAmountDue === 0) {
+      return {
+        nextDueDate: null,
+        newAmountDue: 0,
+        newStatus: 'paid',
+      };
+    }
+
     const currentStatus = RecurrenceService.deriveStatus(bill.dueDate);
 
     return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Fix

**Intent:** Correct PaymentService to properly mark one-time bills as paid when fully paid via partial payment mode. Previously, one-time bills would only receive a "paid" status during full payments (updateDueDate=true), but not when fully paid through partial payments (updateDueDate=false).

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `lib/services/PaymentService.ts` to understand the new conditional branch added to the partial payment path. The key change is in lines 82-89, where a special case handles one-time bills (frequency: 'once') that are fully paid off (newAmountDue === 0) via partial payment mode. This logic returns immediately with paid status and zero amount due, bypassing the normal status derivation. Then examine the corresponding test case in `lib/services/PaymentService.test.ts` at lines 215-229 to see the expected behavior validated.

#### Sensitive Areas

- `lib/services/PaymentService.ts` (lines 82-89): Partial payment path for one-time bills - ensures correct status assignment when a one-time bill is fully paid via partial payment
- `lib/services/PaymentService.test.ts` (lines 215-229): New test case validating that RecurrenceService.deriveStatus is not invoked for this scenario, indicating the special case takes precedence

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes - this is a bug fix that corrects the status for one-time bills when fully paid via partial payments
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->