### PR TITLE
Fix height for expanded payment history

### DIFF
--- a/components/features/bills/BillDetailPanel.tsx
+++ b/components/features/bills/BillDetailPanel.tsx
@@ -147,7 +147,7 @@ export function BillDetailPanel({
       </div>
 
       {/* Details */}
-      <div className="flex-1 space-y-6 overflow-y-auto overflow-x-hidden">
+      <div className={`flex-1 space-y-6 ${isHistoryExpanded ? 'overflow-hidden flex flex-col' : 'overflow-y-auto overflow-x-hidden'}`}>
         {/* Status / Date / Amount Block - Hidden when history expanded */}
         {!isHistoryExpanded && (
           <div className="space-y-1">

--- a/components/features/bills/PaymentHistorySection.tsx
+++ b/components/features/bills/PaymentHistorySection.tsx
@@ -93,17 +93,17 @@ export function PaymentHistorySection({
   }
 
   return (
-    <div className="pt-4 border-t border-border -mx-4 px-4 overflow-x-hidden">
+    <div className="pt-4 border-t border-border -mx-4 px-4 overflow-x-hidden flex-1 flex flex-col min-h-0">
       <button
         type="button"
         onClick={() => onExpandChange(false)}
-        className="flex items-center gap-1 mb-4 text-sm font-medium hover:text-muted-foreground transition-colors cursor-pointer"
+        className="flex items-center gap-1 mb-4 text-sm font-medium hover:text-muted-foreground transition-colors cursor-pointer shrink-0"
       >
         <ChevronLeft className="h-4 w-4" />
         Payment History
       </button>
 
-      <div className="space-y-2 max-h-[300px] overflow-y-auto">
+      <div className="space-y-2 flex-1 overflow-y-auto min-h-0">
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Fix

**Intent:** Resolve layout and height constraints for the expanded payment history section. The fix ensures that when payment history is expanded, it properly utilizes available vertical space by adjusting flex layout properties and overflow behavior, preventing the section from being constrained by fixed height limits.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `components/features/bills/PaymentHistorySection.tsx`. This file contains the expanded state container that now uses `flex-1 flex flex-col min-h-0` - the `min-h-0` is critical as it allows flex children to shrink below content size, enabling proper height distribution. The toggle button is marked with `shrink-0` to maintain its fixed size while the content area can flex and grow.

Then examine `components/features/bills/BillDetailPanel.tsx` at line 150. The Details container conditionally applies layout styles based on `isHistoryExpanded`: when expanded, it switches to `overflow-hidden flex flex-col` (from the default `overflow-y-auto overflow-x-hidden`), which pairs with the child PaymentHistorySection's flex layout to allow proper height distribution and removes the parent's vertical scrollbar.

#### Sensitive Areas

- `components/features/bills/PaymentHistorySection.tsx`: Flex column layout with `min-h-0` constraint on expanded container - ensures proper flex item sizing
- `components/features/bills/BillDetailPanel.tsx` (line 150): Conditional overflow and flex layout switching based on `isHistoryExpanded` state affecting scroll behavior of parent Details container

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->