### PR TITLE
Show  both the remaining amount and the total amount for the current cycle

### DIFF
--- a/components/features/bills/BillDetailPanel.test.tsx
+++ b/components/features/bills/BillDetailPanel.test.tsx
@@ -112,17 +112,26 @@ describe('BillDetailPanel', () => {
     });
 
     it('displays formatted amount (Line 3)', () => {
-      const bill = createMockBill({ amount: 9999 });
+      const bill = createMockBill({ amount: 9999, amountDue: 9999 });
       render(<BillDetailPanel bill={bill} currency="USD" locale="en-US" />);
 
       expect(screen.getByText('$99.99')).toBeInTheDocument();
     });
 
-    it('colors amount red if overdue', () => {
-      const bill = createMockBill({ status: 'overdue' });
+    it('displays partial payment format when amountDue < amount', () => {
+      const bill = createMockBill({ amount: 15000, amountDue: 10000 });
       render(<BillDetailPanel bill={bill} currency="USD" locale="en-US" />);
 
-      const amount = screen.getByText(/\$\d+/);
+      expect(screen.getByText(/\$100\.00/)).toBeInTheDocument();
+      expect(screen.getByText(/\$150\.00/)).toBeInTheDocument();
+      expect(screen.getByText(/\(\$150\.00\)/)).toBeInTheDocument();
+    });
+
+    it('colors amount red if overdue', () => {
+      const bill = createMockBill({ status: 'overdue', amount: 10000, amountDue: 10000 });
+      render(<BillDetailPanel bill={bill} currency="USD" locale="en-US" />);
+
+      const amount = screen.getByText('$100.00');
       expect(amount).toHaveClass('text-red-500');
     });
 

--- a/components/features/bills/BillDetailPanel.tsx
+++ b/components/features/bills/BillDetailPanel.tsx
@@ -160,7 +160,16 @@ export function BillDetailPanel({
             <p
               className={`text-sm font-bold font-mono ${isOverdue ? 'text-red-500' : 'text-white'}`}
             >
-              {formatMoney(bill.amount, currency, locale)}
+              {bill.amountDue < bill.amount && bill.status !== 'paid' ? (
+                <>
+                  {formatMoney(bill.amountDue, currency, locale)}
+                  <span className="ml-1 opacity-70 font-normal text-xs">
+                    ({formatMoney(bill.amount, currency, locale)})
+                  </span>
+                </>
+              ) : (
+                formatMoney(bill.amount, currency, locale)
+              )}
             </p>
             {bill.isVariable && (
               <p className="text-xs text-muted-foreground mt-1">

--- a/docs/features/002-auto-pay.md
+++ b/docs/features/002-auto-pay.md
@@ -14,7 +14,7 @@ The Log Payment dialog captures what you paid, when you paid it, and optionally 
 
 ## The Log Payment dialog
 
-Click the Log Payment button (the banknote icon) on any unpaid bill to open the dialog. You'll see four fields:
+You open the Log Payment dialog through the [Bill Detail Panel](./009-bill-detail-panel-and-skip-payment.md). Click any bill row in the Overview to open the panel, then click the **Log Payment** button. You'll see four fields:
 
 **Amount.** Pre-filled with the bill's current amount due. Change this if you paid a different amount, like when splitting a payment or paying extra.
 
@@ -40,7 +40,7 @@ For example: a $150 monthly bill due March 1. You log a payment with the toggle 
 - The amount due decreases by what you paid
 - The bill remains in your current obligations
 
-For example: a $200 bill due March 15. You log $75 with the toggle off. The due date stays March 15, but the amount due drops to $125. Log the remaining $125 later with the toggle on, and the cycle advances.
+For example: a $200 bill due March 15. You log $75 with the toggle off. The due date stays March 15, but the amount due drops to $125. The [Bill Detail Panel](./009-bill-detail-panel-and-skip-payment.md) now displays your remaining commitment as "$125.00 ($200.00)" so you can see exactly how much is left. Log the remaining $125 later with the toggle on, and the cycle advances.
 
 ## One-time bills
 
@@ -117,10 +117,10 @@ Each payment displays the date (formatted as DD/MM/YYYY), amount, and any notes 
 To confirm payment logging works:
 
 1. Navigate to the Overview and find an unpaid bill.
-2. Click the Log Payment button (banknote icon).
+2. Click the bill row to open the [Bill Detail Panel](./009-bill-detail-panel-and-skip-payment.md) and click the **Log Payment** button.
 3. The dialog should show the amount pre-filled and today's date selected.
 4. Log a payment with "Update Due Date" on. The bill's due date should advance to the next cycle.
-5. Create another bill and log a partial payment with the toggle off. The amount due should decrease while the due date stays the same.
+5. Create another bill and log a partial payment with the toggle off. Verify the Bill Detail Panel displays the remaining balance followed by the total amount in parentheses.
 6. Click "View Payment History" in the Bill Detail Panel. Your logged payments should appear.
 
 To confirm historical payment detection works:

--- a/docs/features/009-bill-detail-panel-and-skip-payment.md
+++ b/docs/features/009-bill-detail-panel-and-skip-payment.md
@@ -20,10 +20,12 @@ The panel uses a bold visual language to signal urgency. The header background c
 You open the panel by clicking any bill row in the Overview table or other bill lists. Selecting a different bill updates the panel content, while clicking the "X" or the background closes it.
 
 ### Information hierarchy
+
 The panel presents information in a prioritized stack:
+
 1. **Status Header:** A plain-language summary like "Due in 2 weeks" or "Overdue by 3 days."
 2. **Specific Date:** The exact date of the obligation (e.g., "Monday, 12 January 2026").
-3. **Amount:** The total amount due. Overdue amounts are highlighted in red to demand attention.
+3. **Amount:** The remaining balance for the current cycle. If you have made partial payments, the display shows your current obligation and the total amount in parentheses, like "$50.00 ($100.00)". Overdue amounts are highlighted in red to demand attention.
 4. **Contextual Data:** Any notes or tags associated with the bill.
 
 ### Core actions
@@ -78,6 +80,7 @@ Hover over a transaction to see the full note text in a tooltip. The list scroll
 
 * **One-time Bills:** The "Skip" button is disabled for bills that repeat "Never." These must either be paid or deleted.
 * **Already Paid:** If a bill is marked as "Paid" (common for one-time bills), both the Log Payment and Skip buttons are disabled.
+* **Partial Payment Visibility:** When you pay only part of a bill and choose not to advance the due date, the panel displays your remaining balance and the total base amount in parentheses. This ensures you never lose sight of the original commitment while celebrating progress.
 * **Negative Margins:** The panel header uses a "full-bleed" design with negative margins to touch the edges of the sidebar, ensuring the status color is the dominant visual element.
 * **Variable Estimates:** If a bill is marked as variable, the amount displayed includes an "(estimate)" label to remind you that the final payment might differ.
 * **Empty History:** Bills with no payments show "No payments recorded yet." in the expanded view.
@@ -89,10 +92,11 @@ To confirm the Bill Detail Panel works as expected:
 1. Open the Overview screen and click on a recurring bill.
 2. Verify the panel slides in and the header background color matches the bill's urgency.
 3. Check that the amount is red if the bill is overdue.
-4. Click "Skip" on a recurring bill. Verify a confirmation toast appears and the due date in the table updates to the next month/interval.
-5. Click on a one-time bill and verify the "Skip" button is disabled.
-6. Look for the "View Payment History" section above the notes.
-7. If the bill has payments, verify the subtitle shows the last payment info. If not, verify it shows "No Payments."
-8. Click "View Payment History" to expand. Verify the status block, action buttons, notes, and tags all hide.
-9. Check the transaction list displays dates, amounts, and notes correctly.
-10. Click the back arrow. Verify all hidden sections reappear.
+4. Log a partial payment (e.g., pay $50 of a $100 bill and disable "Update Due Date"). Verify the panel now displays "$50.00 ($100.00)".
+5. Click "Skip" on a recurring bill. Verify a confirmation toast appears and the due date in the table updates to the next interval.
+6. Click on a one-time bill and verify the "Skip" button is disabled.
+7. Look for the "View Payment History" section above the notes.
+8. If the bill has payments, verify the subtitle shows the last payment info. If not, verify it shows "No Payments."
+9. Click "View Payment History" to expand. Verify the status block, action buttons, notes, and tags all hide.
+10. Check the transaction list displays dates, amounts, and notes correctly.
+11. Click the back arrow. Verify all hidden sections reappear.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Feat

**Intent:** Display both the remaining balance (amountDue) and the total commitment amount for the current billing cycle in the Bill Detail Panel when partial payments have been made. This provides users with clear visibility into how much is left to pay versus the original bill amount.

**Related Issues:** #116

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `components/features/bills/BillDetailPanel.tsx` (lines 163-172) to understand the conditional rendering logic for amount display. The component now checks if `bill.amountDue < bill.amount && bill.status !== 'paid'` to determine whether to display the partial payment format as "$X.00 ($Y.00)" (remaining amount with total in parentheses) or the standard full amount. Then review `components/features/bills/BillDetailPanel.test.tsx` to verify test coverage for partial payment formatting and ensure the mock bill objects properly include both `amount` and `amountDue` fields.

#### Sensitive Areas

- `components/features/bills/BillDetailPanel.tsx` (lines 163-172): Conditional rendering logic for amount display that checks both amountDue comparison and status - requires careful review to ensure paid bills never display confusing partial payment format
- `components/features/bills/BillDetailPanel.test.tsx`: Updated test suite with new partial payment test case and mock bill factory that includes amountDue field

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes - the modifications are additive UI enhancements to component display logic with backward compatibility preserved for paid bills and standard full-payment scenarios
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->