### PR TITLE
Fix rendering when filtering bills by tags

### DIFF
--- a/components/features/bills/TagFilter.test.tsx
+++ b/components/features/bills/TagFilter.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useQueryState } from 'nuqs';
+import { TagFilter } from './TagFilter';
+import type { Tag } from '@/lib/types';
+
+jest.mock('nuqs', () => ({
+  useQueryState: jest.fn(),
+}));
+
+jest.mock('@/lib/search-params', () => ({
+  calendarSearchParams: {
+    tag: {
+      withOptions: jest.fn().mockReturnValue({ shallow: false }),
+    },
+  },
+}));
+
+// Mock scrollIntoView for cmdk
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+const mockTags: Tag[] = [
+  {
+    id: '1',
+    name: 'Utilities',
+    slug: 'utilities',
+    createdAt: new Date(),
+  },
+  {
+    id: '2',
+    name: 'Subscriptions',
+    slug: 'subscriptions',
+    createdAt: new Date(),
+  },
+];
+
+describe('TagFilter', () => {
+  const mockSetSelectedTag = jest.fn();
+
+  beforeEach(() => {
+    (useQueryState as jest.Mock).mockReturnValue([null, mockSetSelectedTag]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls useQueryState with shallow: false configuration', () => {
+    render(<TagFilter tags={mockTags} />);
+
+    expect(useQueryState).toHaveBeenCalledWith(
+      'tag',
+      expect.objectContaining({
+        shallow: false,
+      })
+    );
+  });
+
+  it('updates selection when a tag is clicked in the list', async () => {
+    const user = userEvent.setup();
+    render(<TagFilter tags={mockTags} />);
+
+    await user.click(screen.getByRole('button', { name: /all bills/i }));
+    await user.click(screen.getByText('Utilities'));
+
+    expect(mockSetSelectedTag).toHaveBeenCalledWith('utilities');
+  });
+
+  it('clears selection when the clear button is clicked', async () => {
+    (useQueryState as jest.Mock).mockReturnValue(['utilities', mockSetSelectedTag]);
+    const user = userEvent.setup();
+    render(<TagFilter tags={mockTags} />);
+
+    await user.click(screen.getByRole('button', { name: /clear filter/i }));
+
+    expect(mockSetSelectedTag).toHaveBeenCalledWith(null);
+  });
+});
+

--- a/components/features/bills/TagFilter.tsx
+++ b/components/features/bills/TagFilter.tsx
@@ -18,6 +18,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Badge } from '@/components/ui/badge';
+import { calendarSearchParams } from '@/lib/search-params';
 import type { Tag } from '@/lib/types';
 
 interface TagFilterProps {
@@ -36,7 +37,10 @@ interface TagFilterProps {
  * - Interactive dropdown
  */
 export function TagFilter({ tags }: TagFilterProps) {
-  const [selectedTag, setSelectedTag] = useQueryState('tag');
+  const [selectedTag, setSelectedTag] = useQueryState(
+    'tag',
+    calendarSearchParams.tag.withOptions({ shallow: false })
+  );
 
   const activeTag = tags.find((t) => t.slug === selectedTag);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       "devDependencies": {
         "@faker-js/faker": "^10.1.0",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@faker-js/faker": "^10.1.0",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Fix

**Intent:** Fix rendering issues when filtering bills by tags by enabling full page navigation instead of shallow client-side updates. The tag filter now uses the `shallow: false` option in `useQueryState` to ensure proper re-rendering of the bills list when the selected tag changes.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `components/features/bills/TagFilter.tsx` to understand the core fix. The key change is on line 40-43 where `useQueryState` is now called with `calendarSearchParams.tag.withOptions({ shallow: false })`. This configuration enables full page navigation when the tag selection changes, rather than shallow client-side state updates. The `shallow: false` option ensures the entire page re-renders to properly reflect filtered bills. Then review `components/features/bills/TagFilter.test.tsx` to understand the expected behavior through the test assertions.

#### Sensitive Areas

- `components/features/bills/TagFilter.tsx`: The `useQueryState` hook configuration with `shallow: false` option - this is critical for proper re-rendering behavior when tag selection changes
- `components/features/bills/TagFilter.test.tsx`: Mock setup for `calendarSearchParams.tag.withOptions` to verify the shallow option is correctly passed

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->