### PR TITLE
Replace Screen with View terminology across documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,11 +18,11 @@ Explanations of user-facing functionality and domain logic. Start with the found
 
 | Document | Description |
 |----------|-------------|
-| [Overview Screen](./features/005-overview-screen.md) | The main screen for managing all bills |
-| [Due Soon Screen](./features/008-due-soon-screen.md) | Bills due within a configurable time range |
-| [Due This Month Screen](./features/004-due-this-month.md) | Bills due in the current calendar month |
-| [Paid Recently Screen](./features/014-paid-recently-screen.md) | Payments made within a configurable lookback period |
-| [Archive Screen](./features/013-archive-screen.md) | Viewing and managing archived bills |
+| [Overview View](./features/005-overview-view.md) | The main view for managing all bills |
+| [Due Soon View](./features/008-due-soon-view.md) | Bills due within a configurable time range |
+| [Due This Month View](./features/004-due-this-month.md) | Bills due in the current calendar month |
+| [Paid Recently View](./features/014-paid-recently-view.md) | Payments made within a configurable lookback period |
+| [Archive View](./features/013-archive-view.md) | Viewing and managing archived bills |
 
 ### Foundation
 

--- a/docs/features/000-active-payer-philosophy.md
+++ b/docs/features/000-active-payer-philosophy.md
@@ -79,6 +79,6 @@ Passive systems encourage you to set it and forget it. Active Payer systems enco
 
 * [Logging Payments](./002-auto-pay.md) - Recording payments, partial payments, and historical payment detection
 * [Active Payer Signals](./010-active-payer-signals.md) - Explicit payment mode indicators (Auto/Manual) for each bill
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Overview View](./005-overview-view.md) - The main view for managing all bills
 * [Editing Payment History](./011-editing-payment-history.md) - Correcting payment mistakes and managing payment records
 

--- a/docs/features/002-auto-pay.md
+++ b/docs/features/002-auto-pay.md
@@ -139,4 +139,4 @@ To confirm historical payment detection works:
 
 * [Recurrence Engine](./001-recurrence-engine.md) - How recurring and one-time payments advance
 * [Background Jobs](./006-background-jobs.md) - Automated system tasks
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Overview View](./005-overview-view.md) - The main view for managing all bills

--- a/docs/features/004-due-this-month.md
+++ b/docs/features/004-due-this-month.md
@@ -1,4 +1,4 @@
-# Due This Month Screen
+# Due This Month View
 
 - **Status:** Draft
 - **Last Updated:** 2025-12-25
@@ -13,7 +13,7 @@ The sidebar navigation displays a summary below the "Due This Month" menu item s
 
 ## How it differs from Overview
 
-The [Overview screen](./005-overview-screen.md) shows all your bills, optionally filtered by a specific date or tag. The Due This Month view automatically filters to show only unpaid bills due in the current calendar month.
+The [Overview view](./005-overview-view.md) shows all your bills, optionally filtered by a specific date or tag. The Due This Month view automatically filters to show only unpaid bills due in the current calendar month.
 
 **Overview:**
 - Shows all bills by default
@@ -110,5 +110,5 @@ To confirm the Due This Month feature works:
 
 ## Related Documents
 
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Overview View](./005-overview-view.md) - The main view for managing all bills
 * [Logging Payments](./002-auto-pay.md) - Recording payments, partial payments, and historical payment detection

--- a/docs/features/005-overview-view.md
+++ b/docs/features/005-overview-view.md
@@ -1,11 +1,11 @@
-# Overview Screen
+# Overview View
 
 - **Status:** Draft
 - **Last Updated:** 2025-12-25
 
 ## Overview
 
-The Overview screen is your command center for managing bills. It displays all your bills in a table with four columns: category icon, name, amount, and due date. Each bill shows when payment is due using plain language like "Due in 3 days" or "Overdue by 5 days" so you can prioritize at a glance.
+The Overview view is your command center for managing bills. It displays all your bills in a table with four columns: category icon, name, amount, and due date. Each bill shows when payment is due using plain language like "Due in 3 days" or "Overdue by 5 days" so you can prioritize at a glance.
 
 A colored status bar on the left edge of the due date cell gives you instant visual feedback about each bill's urgency. Red means overdue, amber means due soon, blue means you have time, and green means paid.
 
@@ -105,7 +105,7 @@ See the [Logging Payments](./002-auto-pay.md) documentation for details on the p
 
 Clicking anywhere on a bill row opens the **Bill Detail Panel**. Management actions for the selected bill are located at the bottom of this panel:
 
-- **Archive:** Moves the bill to your archive (removes it from active views). Archived bills can be accessed through the [Archive Screen](./013-archive-screen.md).
+- **Archive:** Moves the bill to your archive (removes it from active views). Archived bills can be accessed through the [Archive View](./013-archive-view.md).
 - **Edit:** Opens the bill form to modify title, amount, repeat interval, category, or tags.
 - **Delete:** Removes the bill entirely (requires confirmation).
 
@@ -127,7 +127,7 @@ Payment history is available directly within the Bill Detail Panel through the c
 
 ## Verification
 
-To confirm the Overview screen works:
+To confirm the Overview view works:
 
 1. Navigate to the Overview page. You should see a table with four columns.
 2. Check that bill names show combined subtitles like "Every month • Manual" or "Every month • Auto" below them. Verify the bullet point separates the interval from the payment mode.
@@ -144,4 +144,4 @@ To confirm the Overview screen works:
 
 * [Bill Detail Panel & Skip Payment](./009-bill-detail-panel-and-skip-payment.md) - The panel for managing a specific bill
 * [Logging Payments](./002-auto-pay.md) - Recording payments, partial payments, and historical payment detection
-* [Archive Screen](./013-archive-screen.md) - Viewing and managing archived bills
+* [Archive View](./013-archive-view.md) - Viewing and managing archived bills

--- a/docs/features/008-due-soon-view.md
+++ b/docs/features/008-due-soon-view.md
@@ -1,17 +1,17 @@
-# Due Soon Screen
+# Due Soon View
 
 - **Status:** Draft
 - **Last Updated:** 2025-12-25
 
 ## Overview
 
-The Due Soon screen answers one question: "What needs my attention right now?" While the [Due This Month](./004-due-this-month.md) view shows your full monthly picture, Due Soon narrows the focus to imminent obligations.
+The Due Soon view answers one question: "What needs my attention right now?" While the [Due This Month](./004-due-this-month.md) view shows your full monthly picture, Due Soon narrows the focus to imminent obligations.
 
 The range is configurable. Set it to 3 days for tight weekly reviews, or stretch it to 30 days for monthly planning sessions. This flexibility lets you tune the view to match your personal financial rhythm.
 
 ## How it differs from Due This Month
 
-Both screens filter for unpaid bills, but they use different time windows:
+Both views filter for unpaid bills, but they use different time windows:
 
 **Due This Month:**
 - Fixed to the current calendar month (1st through last day)
@@ -125,6 +125,6 @@ To confirm the Due Soon feature works:
 
 ## Related Documents
 
-* [Due This Month Screen](./004-due-this-month.md) - Bills due in the current calendar month
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Due This Month View](./004-due-this-month.md) - Bills due in the current calendar month
+* [Overview View](./005-overview-view.md) - The main view for managing all bills
 

--- a/docs/features/009-bill-detail-panel-and-skip-payment.md
+++ b/docs/features/009-bill-detail-panel-and-skip-payment.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Oar emphasizes intentionality in financial management. While the Overview screen provides a high-level table view of your obligations, the **Bill Detail Panel** is where you focus on a specific commitment and decide how to handle it.
+Oar emphasizes intentionality in financial management. While the Overview view provides a high-level table view of your obligations, the **Bill Detail Panel** is where you focus on a specific commitment and decide how to handle it.
 
 The panel appears when you click on a bill in any list. It strips away the surrounding noise to present a clear "Active Payer" decision point: do you pay this bill now, or do you skip this specific occurrence?
 
@@ -79,7 +79,7 @@ Click any payment row to view its details and edit or delete it. See [Editing Pa
 
 ## Edge cases and constraints
 
-* **Archived Bills:** When viewing an archived bill (accessed through the [Archive Screen](./013-archive-screen.md)), the panel behavior changes. The "Log Payment" and "Skip" buttons are hidden, the "Archive" button becomes "Unarchive," and the due date displays "Never / Archived" instead of relative dates. The header uses neutral colors rather than urgency-based status colors.
+* **Archived Bills:** When viewing an archived bill (accessed through the [Archive View](./013-archive-view.md)), the panel behavior changes. The "Log Payment" and "Skip" buttons are hidden, the "Archive" button becomes "Unarchive," and the due date displays "Never / Archived" instead of relative dates. The header uses neutral colors rather than urgency-based status colors.
 * **One-time Bills:** The "Skip" button is disabled for bills that repeat "Never." These must either be paid or deleted.
 * **Already Paid:** If a bill is marked as "Paid" (common for one-time bills), both the Log Payment and Skip buttons are disabled.
 * **Partial Payment Visibility:** When you pay only part of a bill and choose not to advance the due date, the panel displays your remaining balance and the total base amount in parentheses. This ensures you never lose sight of the original commitment while celebrating progress.
@@ -91,7 +91,7 @@ Click any payment row to view its details and edit or delete it. See [Editing Pa
 ## Verification
 
 To confirm the Bill Detail Panel works as expected:
-1. Open the Overview screen and click on a recurring bill.
+1. Open the Overview view and click on a recurring bill.
 2. Verify the panel slides in and the header background color matches the bill's urgency.
 3. Check that the amount is red if the bill is overdue.
 4. Log a partial payment (e.g., pay $50 of a $100 bill and disable "Update Due Date"). Verify the panel now displays "$50.00 ($100.00)".
@@ -105,7 +105,7 @@ To confirm the Bill Detail Panel works as expected:
 
 ## Related Documents
 
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Overview View](./005-overview-view.md) - The main view for managing all bills
 * [Logging Payments](./002-auto-pay.md) - Recording payments, partial payments, and historical payment detection
 * [Editing Payment History](./011-editing-payment-history.md) - Correcting payment mistakes and managing payment records
-* [Archive Screen](./013-archive-screen.md) - Viewing and managing archived bills
+* [Archive View](./013-archive-view.md) - Viewing and managing archived bills

--- a/docs/features/010-active-payer-signals.md
+++ b/docs/features/010-active-payer-signals.md
@@ -22,7 +22,7 @@ By labeling these bills explicitly in the Overview, we shift the type of control
 
 ## The auto/manual indicator
 
-Every bill in the [Overview Screen](./005-overview-screen.md) displays its payment mode right below the title, alongside its repeat interval.
+Every bill in the [Overview View](./005-overview-view.md) displays its payment mode right below the title, alongside its repeat interval.
 
 ### Visual Representation
 
@@ -60,7 +60,7 @@ To confirm the signals are working as intended:
 
 ## Related Documents
 
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Overview View](./005-overview-view.md) - The main view for managing all bills
 * [Logging Payments](./002-auto-pay.md) - Recording payments, partial payments, and historical payment detection
 * [Background Jobs](./006-background-jobs.md) - Automated system tasks
 

--- a/docs/features/012-after-a-bill-ends-setting.md
+++ b/docs/features/012-after-a-bill-ends-setting.md
@@ -27,7 +27,7 @@ You find the "After a Bill Ends" setting in Settings under General → Behavior 
 
 **Mark as Never Due (default).** When a bill ends, it stays visible in your bill list. The status changes to "paid," the amount due becomes zero, and there's no next due date. The bill remains in your active views so you can reference it, but it won't appear in "Due Soon" or other time-based filters. This is useful when you want to keep a record of completed bills without cluttering your active obligations.
 
-**Move to the Archive.** When a bill ends, it's immediately archived. The bill disappears from your active bill list, "Due Soon" screen, and other active views. You can still access it through the [Archive Screen](./013-archive-screen.md), but it's out of the way. This is useful when you want a clean separation between active bills and completed ones.
+**Move to the Archive.** When a bill ends, it's immediately archived. The bill disappears from your active bill list, "Due Soon" view, and other active views. You can still access it through the [Archive View](./013-archive-view.md), but it's out of the way. This is useful when you want a clean separation between active bills and completed ones.
 
 The setting applies globally to all bills. You can't set different behaviors for different bills. This keeps the system simple and predictable. Once you choose your preference, every bill that ends follows that rule.
 
@@ -55,7 +55,7 @@ Here's what happens when a bill ends:
 
 **Changing the setting after bills have ended.** If you change the "After a Bill Ends" setting, it only affects bills that end after the change. Bills that already ended keep their current state. You can manually archive or unarchive bills later if needed.
 
-**Archived bills remain accessible.** When a bill is archived, it's not deleted. It's still in your database, and you can access it through the [Archive Screen](./013-archive-screen.md). You can also unarchive it later if you need to reference it or reactivate it.
+**Archived bills remain accessible.** When a bill is archived, it's not deleted. It's still in your database, and you can access it through the [Archive View](./013-archive-view.md). You can also unarchive it later if you need to reference it or reactivate it.
 
 **Auto-pay bills and bill end.** If you have auto-pay enabled on a bill that ends, the system still processes the final payment automatically. The bill end detection happens after the auto-payment, and the setting applies the same way as manual payments.
 
@@ -97,6 +97,6 @@ To test the "Never" interval scenario:
 
 * [Logging Payments](./002-auto-pay.md) - Recording payments, partial payments, and historical payment detection
 * [Bill Detail Panel & Skip Payment](./009-bill-detail-panel-and-skip-payment.md) - The panel for managing a specific bill
-* [Archive Screen](./013-archive-screen.md) - Viewing and managing archived bills
+* [Archive View](./013-archive-view.md) - Viewing and managing archived bills
 * [Recurrence Engine](./001-recurrence-engine.md) - How recurring and one-time payments advance
 

--- a/docs/features/013-archive-view.md
+++ b/docs/features/013-archive-view.md
@@ -1,4 +1,4 @@
-# Archive Screen
+# Archive View
 
 - **Status:** Draft
 - **Last Updated:** 2025-12-25
@@ -11,7 +11,7 @@ The Archive maintains the Active Payer philosophy by keeping archived bills acce
 
 ## Why archive exists
 
-Active bill views focus on what needs your attention now. The Overview screen shows all active bills, Due Soon highlights imminent obligations, and Due This Month displays your monthly commitments. Archived bills don't belong in these views because they represent past or paused commitments.
+Active bill views focus on what needs your attention now. The Overview view shows all active bills, Due Soon highlights imminent obligations, and Due This Month displays your monthly commitments. Archived bills don't belong in these views because they represent past or paused commitments.
 
 The Archive serves as a dedicated space for bills that are temporarily or permanently inactive. Whether you manually archived a bill because you paused a subscription, or it was automatically archived when it ended (if you configured the "After a Bill Ends" setting to "Move to the Archive"), the Archive keeps them organized and accessible.
 
@@ -114,7 +114,7 @@ To confirm the Archive feature works as expected:
 
 ## Related Documents
 
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Overview View](./005-overview-view.md) - The main view for managing all bills
 * [Bill Detail Panel & Skip Payment](./009-bill-detail-panel-and-skip-payment.md) - The panel for managing a specific bill
 * [After a Bill Ends Setting](./012-after-a-bill-ends-setting.md) - What happens when a bill ends
 

--- a/docs/features/014-paid-recently-view.md
+++ b/docs/features/014-paid-recently-view.md
@@ -1,17 +1,17 @@
-# Paid Recently Screen
+# Paid Recently View
 
 - **Status:** Draft
 - **Last Updated:** 2025-12-25
 
 ## Overview
 
-The Paid Recently screen shows payments you've logged within a configurable lookback period. Unlike bill views that focus on upcoming obligations, this screen looks backward to show what you've already paid. It helps you track your payment activity and verify that payments were recorded correctly.
+The Paid Recently view shows payments you've logged within a configurable lookback period. Unlike bill views that focus on upcoming obligations, this view looks backward to show what you've already paid. It helps you track your payment activity and verify that payments were recorded correctly.
 
 The range is configurable from 0 to 30 days, letting you adjust how far back you want to see. Set it to 3 days for a tight view of recent activity, or stretch it to 30 days for a broader payment history review.
 
 ## How it differs from bill views
 
-Bill views like Overview, Due Soon, and Due This Month show unpaid bills - what you still need to pay. The Paid Recently screen shows completed payments - what you've already paid. These views complement each other: one shows obligations, the other shows completed transactions.
+Bill views like Overview, Due Soon, and Due This Month show unpaid bills - what you still need to pay. The Paid Recently view shows completed payments - what you've already paid. These views complement each other: one shows obligations, the other shows completed transactions.
 
 **Bill views:**
 - Show unpaid bills with due dates
@@ -128,6 +128,6 @@ To confirm the Paid Recently feature works:
 
 ## Related Documents
 
-* [Due Soon Screen](./008-due-soon-screen.md) - Bills due within a configurable time range
+* [Due Soon View](./008-due-soon-view.md) - Bills due within a configurable time range
 * [Logging Payments](./002-auto-pay.md) - Recording payments, partial payments, and historical payment detection
 

--- a/docs/features/015-hiding-the-sidebar.md
+++ b/docs/features/015-hiding-the-sidebar.md
@@ -70,5 +70,5 @@ To confirm the sidebar toggle works:
 
 ## Related Documents
 
-* [Overview Screen](./005-overview-screen.md) - The main screen for managing all bills
+* [Overview View](./005-overview-view.md) - The main view for managing all bills
 * [Organizing Bills with Tags](./003-organizing-bills-with-tags.md) - Categorizing bills with tags


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Chore

**Intent:** Standardize documentation terminology by renaming all feature "Screen" references to "View" across the features documentation. This improves consistency and clarity in labeling user interface components throughout the feature documentation.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `docs/README.md` to understand the Views table updates. This file provides a high-level overview of all affected components. Then review the individual feature files in `docs/features/` to verify that link targets and cross-references have been updated consistently. Key files to examine: `docs/features/005-overview-view.md` (formerly Overview Screen), `docs/features/008-due-soon-view.md` (formerly Due Soon Screen), `docs/features/013-archive-view.md` (formerly Archive Screen), and `docs/features/014-paid-recently-view.md` (formerly Paid Recently Screen).

#### Sensitive Areas

- `docs/features/005-overview-view.md`, `docs/features/013-archive-view.md`: Primary renamed documents that other files link to - verify all cross-references have been updated
- `docs/features/009-bill-detail-panel-and-skip-payment.md`: Multiple terminology replacements alongside new edge cases and verification steps - ensure consistency

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes - all modifications are documentation updates with no functional impact to codebase or build process
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->