### PR TITLE
Add initialDimension prop for SSR support in charts

### DIFF
--- a/components/features/forecast/ForecastChart.test.tsx
+++ b/components/features/forecast/ForecastChart.test.tsx
@@ -25,11 +25,19 @@ jest.mock('@/components/ui/chart', () => ({
   ChartContainer: ({
     children,
     config,
+    initialDimension,
   }: {
     children: React.ReactNode;
     config: Record<string, unknown>;
+    initialDimension?: { width: number; height: number };
   }) => (
-    <div data-testid="chart-container" data-config={JSON.stringify(config)}>
+    <div
+      data-testid="chart-container"
+      data-config={JSON.stringify(config)}
+      data-initial-dimension={
+        initialDimension ? JSON.stringify(initialDimension) : null
+      }
+    >
       {children}
     </div>
   ),
@@ -263,6 +271,22 @@ describe('ForecastChart', () => {
       'PLN',
       'pl-PL'
     );
+  });
+
+  it('passes initialDimension to ChartContainer for SSR support', () => {
+    render(
+      <ForecastChart
+        data={mockData}
+        currency="USD"
+        locale="en-US"
+      />
+    );
+
+    const container = screen.getByTestId('chart-container');
+    const dimensionAttr = container.getAttribute('data-initial-dimension');
+    const initialDimension = dimensionAttr ? JSON.parse(dimensionAttr) : null;
+
+    expect(initialDimension).toEqual({ width: 800, height: 200 });
   });
 });
 

--- a/components/features/forecast/ForecastChart.tsx
+++ b/components/features/forecast/ForecastChart.tsx
@@ -57,7 +57,11 @@ export function ForecastChart({
 
   return (
     <div className="relative h-[200px] w-full">
-      <ChartContainer config={chartConfig} className="h-full w-full">
+      <ChartContainer
+        config={chartConfig}
+        className="h-full w-full"
+        initialDimension={{ width: 800, height: 200 }}
+      >
         <BarChart accessibilityLayer data={chartData}>
           <CartesianGrid vertical={false} />
           <XAxis

--- a/components/features/history/MonthlyHistoryChart.test.tsx
+++ b/components/features/history/MonthlyHistoryChart.test.tsx
@@ -20,11 +20,19 @@ jest.mock('@/components/ui/chart', () => ({
   ChartContainer: ({
     children,
     config,
+    initialDimension,
   }: {
     children: React.ReactNode;
     config: Record<string, unknown>;
+    initialDimension?: { width: number; height: number };
   }) => (
-    <div data-testid="chart-container" data-config={JSON.stringify(config)}>
+    <div
+      data-testid="chart-container"
+      data-config={JSON.stringify(config)}
+      data-initial-dimension={
+        initialDimension ? JSON.stringify(initialDimension) : null
+      }
+    >
       {children}
     </div>
   ),
@@ -260,6 +268,22 @@ describe('MonthlyHistoryChart', () => {
     expect(screen.getByTestId('chart-container')).toBeInTheDocument();
     expect(screen.getByTestId('bar-currentYear')).toBeInTheDocument();
     expect(screen.getByTestId('bar-lastYear')).toBeInTheDocument();
+  });
+
+  it('passes initialDimension to ChartContainer for SSR support', () => {
+    render(
+      <MonthlyHistoryChart
+        data={mockData}
+        currency="USD"
+        locale="en-US"
+      />
+    );
+
+    const container = screen.getByTestId('chart-container');
+    const dimensionAttr = container.getAttribute('data-initial-dimension');
+    const initialDimension = dimensionAttr ? JSON.parse(dimensionAttr) : null;
+
+    expect(initialDimension).toEqual({ width: 800, height: 200 });
   });
 });
 

--- a/components/features/history/MonthlyHistoryChart.tsx
+++ b/components/features/history/MonthlyHistoryChart.tsx
@@ -88,7 +88,11 @@ export function MonthlyHistoryChart({
 
   return (
     <div className="relative h-[200px] w-full">
-      <ChartContainer config={chartConfig} className="h-full w-full">
+      <ChartContainer
+        config={chartConfig}
+        className="h-full w-full"
+        initialDimension={{ width: 800, height: 200 }}
+      >
         <BarChart accessibilityLayer data={data}>
           <CartesianGrid vertical={false} />
           <XAxis

--- a/components/ui/chart.test.tsx
+++ b/components/ui/chart.test.tsx
@@ -201,8 +201,23 @@ describe('sanitizeColorValue', () => {
 });
 
 jest.mock('recharts', () => ({
-  ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
-    React.createElement('div', { 'data-testid': 'responsive-container' }, children),
+  ResponsiveContainer: ({
+    children,
+    initialDimension,
+  }: {
+    children: React.ReactNode;
+    initialDimension?: { width: number; height: number };
+  }) =>
+    React.createElement(
+      'div',
+      {
+        'data-testid': 'responsive-container',
+        'data-initial-dimension': initialDimension
+          ? JSON.stringify(initialDimension)
+          : null,
+      },
+      children
+    ),
 }));
 
 describe('ChartContainer', () => {
@@ -406,6 +421,32 @@ describe('ChartContainer', () => {
 
     const styleElement = container.querySelector('style');
     expect(styleElement?.textContent).toContain('hsl(var(--primary))');
+  });
+
+  it('passes initialDimension to ResponsiveContainer when provided', () => {
+    const initialDimension = { width: 800, height: 200 };
+
+    render(
+      <ChartContainer config={mockConfig} initialDimension={initialDimension}>
+        <div>Content</div>
+      </ChartContainer>
+    );
+
+    const responsiveContainer = screen.getByTestId('responsive-container');
+    const dimensionAttr = responsiveContainer.getAttribute('data-initial-dimension');
+    expect(dimensionAttr).toBe(JSON.stringify(initialDimension));
+  });
+
+  it('does not pass initialDimension to ResponsiveContainer when not provided', () => {
+    render(
+      <ChartContainer config={mockConfig}>
+        <div>Content</div>
+      </ChartContainer>
+    );
+
+    const responsiveContainer = screen.getByTestId('responsive-container');
+    const dimensionAttr = responsiveContainer.getAttribute('data-initial-dimension');
+    expect(dimensionAttr).toBeNull();
   });
 });
 

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -93,8 +93,9 @@ const ChartContainer = React.forwardRef<
     children: React.ComponentProps<
       typeof RechartsPrimitive.ResponsiveContainer
     >['children'];
+    initialDimension?: { width: number; height: number };
   }
->(({ id, className, children, config, ...props }, ref) => {
+>(({ id, className, children, config, initialDimension, ...props }, ref) => {
   const uniqueId = React.useId();
   const chartId = `chart-${escapeCssIdentifier(id || uniqueId)}`;
 
@@ -109,7 +110,9 @@ const ChartContainer = React.forwardRef<
       {...props}
     >
       <ChartStyle id={chartId} config={config} />
-      <RechartsPrimitive.ResponsiveContainer>
+      <RechartsPrimitive.ResponsiveContainer
+        initialDimension={initialDimension}
+      >
         {children}
       </RechartsPrimitive.ResponsiveContainer>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Fix

**Intent:** Add Server-Side Rendering (SSR) support for chart components by introducing an optional `initialDimension` prop that allows explicit setting of chart dimensions, ensuring proper rendering dimensions are available during server-side rendering.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `components/ui/chart.tsx` to understand the core implementation. The `ChartContainer` component now accepts an optional `initialDimension?: { width: number; height: number }` prop and forwards it to the underlying `RechartsPrimitive.ResponsiveContainer`. Then examine how this prop is consumed in the feature components (`components/features/forecast/ForecastChart.tsx` and `components/features/history/MonthlyHistoryChart.tsx`), which both set `initialDimension={{ width: 800, height: 200 }}` to establish consistent initial chart sizing for SSR.

#### Sensitive Areas

- `components/ui/chart.tsx` - Core prop threading and forwarding to ResponsiveContainer
- `components/ui/chart.test.tsx` - Comprehensive test coverage for dimension prop passing and omission
- `components/features/forecast/ForecastChart.tsx` and `components/features/history/MonthlyHistoryChart.tsx` - Usage of the new prop with hardcoded dimensions
- Feature component test files - Mock updates to verify SSR dimension propagation

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes - the `initialDimension` prop is optional and fully backward compatible
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->