### PR TITLE
Improve SettingsService tests and increase coverage

### DIFF
--- a/lib/services/SettingsService.test.ts
+++ b/lib/services/SettingsService.test.ts
@@ -607,7 +607,10 @@ describe('SettingsService', () => {
       const result = await SettingsService.getDueSoonRange();
 
       expect(result).toBe(7);
-      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        { invalidValue: '99' },
+        'Invalid dueSoonRange value, defaulting to 7'
+      );
     });
   });
 
@@ -976,12 +979,12 @@ describe('SettingsService', () => {
 
       expect(db.transaction).toHaveBeenCalled();
 
-      const insertCalls = (db.insert as jest.Mock).mock.calls;
-      const insertResults = (db.insert as jest.Mock).mock.results;
+      const insertCalls = txInsertMock.mock.calls;
+      const insertResults = txInsertMock.mock.results;
 
       const totalInserts =
         DEFAULT_CATEGORIES.length + DEFAULT_SECTIONS.length + DEFAULT_SETTINGS_VALUES.length;
-      expect(db.insert).toHaveBeenCalledTimes(totalInserts);
+      expect(txInsertMock).toHaveBeenCalledTimes(totalInserts);
 
       let callIndex = 0;
       for (const cat of DEFAULT_CATEGORIES) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### 🎯 Scope & Context
**Type:** Chore  
**Intent:** Expand and harden unit tests for SettingsService by adding a reusable, typed mock QueryBuilder, centralized mocks for loggers/constants, and comprehensive test cases that cover success paths, error handling, type coercions, transactional inserts, and default-seeding behavior.

### 🧭 Reviewer Guide
**Complexity:** Medium

#### Entry Point
Start with `lib/services/SettingsService.test.ts` — it contains the new mock infrastructure (factories like `createSelectBuilder` / `createSelectBuilderSync`) that simulate chained query-builder behaviour, transaction flows, onConflict upserts, and batched responses. Reviewing this file explains how tests inject DB responses and exercise service methods end-to-end.

#### Sensitive Areas
- `lib/services/SettingsService.test.ts` - new mock QueryBuilder factories and many of the added test cases (core of the change).  
- Tests around numeric and boolean coercion - verifying conversion of numbers/booleans to string storage (weekStart, includeAutoPayInDueSoon, ranges).  
- Transactional flows and upsert semantics - tests asserting onConflictDoUpdate / onConflictDoNothing and multi-step insert/select sequences.  
- Initialization/seeding tests - `initializeDefaults` / `ensureDefaultSettings` behaviour and idempotency with existing data.  
- Logger usage in failure paths - tests asserting error reporting for invalid inputs or missing sections.

### ⚠️ Risk Assessment
- **Breaking Changes:** No breaking changes - production code signatures unchanged; modifications are test-only.  
- **Migrations/State:** No migrations or state changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->