### PR TITLE
Introduce Auto-Log Auto-Pay Bills Setting

### DIFF
--- a/actions/settings.test.ts
+++ b/actions/settings.test.ts
@@ -6,6 +6,7 @@ import {
   updateBillEndAction,
   updateWeekendAdjustment,
   getWeekendAdjustment,
+  updateAutoLogAutoPay,
 } from './settings';
 import { SettingsService } from '@/lib/services/SettingsService';
 import { revalidatePath } from 'next/cache';
@@ -23,6 +24,7 @@ jest.mock('@/lib/services/SettingsService', () => ({
     setBillEndAction: jest.fn(),
     setWeekendAdjustment: jest.fn(),
     getWeekendAdjustment: jest.fn(),
+    set: jest.fn(),
   },
 }));
 jest.mock('@/db', () => ({
@@ -470,5 +472,53 @@ describe('getWeekendAdjustment', () => {
 
     const logger = getLogger('test');
     expect(logger.error).toHaveBeenCalledWith(error, 'Failed to fetch weekend adjustment');
+  });
+});
+
+describe('updateAutoLogAutoPay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates setting successfully when enabled is true', async () => {
+    (SettingsService.set as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await updateAutoLogAutoPay({ enabled: true });
+
+    expect(result.success).toBe(true);
+    expect(SettingsService.set).toHaveBeenCalledWith('autoLogAutoPay', true);
+    expect(revalidatePath).toHaveBeenCalledWith('/settings');
+  });
+
+  it('updates setting successfully when enabled is false', async () => {
+    (SettingsService.set as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await updateAutoLogAutoPay({ enabled: false });
+
+    expect(result.success).toBe(true);
+    expect(SettingsService.set).toHaveBeenCalledWith('autoLogAutoPay', false);
+    expect(revalidatePath).toHaveBeenCalledWith('/settings');
+  });
+
+  it('returns validation error for invalid input', async () => {
+    const result = await updateAutoLogAutoPay({ enabled: 'invalid' as unknown as boolean });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Validation failed');
+    expect(result.fieldErrors).toBeDefined();
+    expect(SettingsService.set).not.toHaveBeenCalled();
+  });
+
+  it('returns error when service throws', async () => {
+    const error = new Error('Database error');
+    (SettingsService.set as jest.Mock).mockRejectedValue(error);
+
+    const result = await updateAutoLogAutoPay({ enabled: true });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Failed to update setting');
+
+    const logger = getLogger('test');
+    expect(logger.error).toHaveBeenCalledWith(error, 'Failed to update auto-log auto-pay setting');
   });
 });

--- a/actions/settings.ts
+++ b/actions/settings.ts
@@ -192,6 +192,10 @@ const updateWeekendAdjustmentSchema = z.object({
   strategy: z.enum(['unchanged', 'next_business_day', 'previous_business_day']),
 });
 
+const updateAutoLogAutoPaySchema = z.object({
+  enabled: z.boolean(),
+});
+
 /**
  * Updates the global weekend adjustment strategy setting.
  *
@@ -241,6 +245,38 @@ export async function getWeekendAdjustment(): Promise<ActionResult<WeekendAdjust
     return {
       success: false,
       error: 'Failed to load setting',
+    };
+  }
+}
+
+/**
+ * Updates the "automatically log auto-pay bills" setting.
+ *
+ * @param input - Object containing the enabled boolean value
+ * @returns ActionResult indicating success or failure
+ */
+export async function updateAutoLogAutoPay(
+  input: z.infer<typeof updateAutoLogAutoPaySchema>
+): Promise<ActionResult<void>> {
+  const parsed = updateAutoLogAutoPaySchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: 'Validation failed',
+      fieldErrors: z.flattenError(parsed.error).fieldErrors,
+    };
+  }
+
+  try {
+    await SettingsService.set('autoLogAutoPay', parsed.data.enabled);
+    revalidatePath('/settings');
+    return { success: true };
+  } catch (error) {
+    logger.error(error, 'Failed to update auto-log auto-pay setting');
+    return {
+      success: false,
+      error: 'Failed to update setting',
     };
   }
 }

--- a/components/common/SettingCheckbox.test.tsx
+++ b/components/common/SettingCheckbox.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SettingCheckbox } from './SettingCheckbox';
+
+describe('SettingCheckbox', () => {
+  const defaultProps = {
+    id: 'test-checkbox',
+    label: 'Test Setting',
+    checked: false,
+    onCheckedChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders label and switch', () => {
+    render(<SettingCheckbox {...defaultProps} />);
+
+    expect(screen.getByText('Test Setting')).toBeInTheDocument();
+    const switchElement = document.getElementById('test-checkbox');
+    expect(switchElement).toBeInTheDocument();
+  });
+
+  it('associates label with switch via htmlFor', () => {
+    render(<SettingCheckbox {...defaultProps} />);
+
+    const label = screen.getByText('Test Setting');
+    expect(label).toHaveAttribute('for', 'test-checkbox');
+  });
+
+  it('renders switch as checked when checked prop is true', () => {
+    render(<SettingCheckbox {...defaultProps} checked={true} />);
+
+    const switchElement = document.getElementById('test-checkbox') as HTMLButtonElement;
+    expect(switchElement).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders switch as unchecked when checked prop is false', () => {
+    render(<SettingCheckbox {...defaultProps} checked={false} />);
+
+    const switchElement = document.getElementById('test-checkbox') as HTMLButtonElement;
+    expect(switchElement).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('renders description when provided', () => {
+    render(
+      <SettingCheckbox
+        {...defaultProps}
+        description="This is a test description"
+      />
+    );
+
+    expect(screen.getByText('This is a test description')).toBeInTheDocument();
+  });
+
+  it('does not render description when not provided', () => {
+    render(<SettingCheckbox {...defaultProps} />);
+
+    expect(screen.queryByText(/description/i)).not.toBeInTheDocument();
+  });
+
+  it('calls onCheckedChange when switch is toggled', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    render(<SettingCheckbox {...defaultProps} onCheckedChange={mockOnChange} />);
+
+    const switchElement = document.getElementById('test-checkbox') as HTMLButtonElement;
+    await user.click(switchElement);
+
+    expect(mockOnChange).toHaveBeenCalledWith(true);
+  });
+
+  it('disables switch when disabled prop is true', () => {
+    render(<SettingCheckbox {...defaultProps} disabled={true} />);
+
+    const switchElement = document.getElementById('test-checkbox') as HTMLButtonElement;
+    expect(switchElement).toBeDisabled();
+  });
+
+  it('disables switch when isLoading is true', () => {
+    render(<SettingCheckbox {...defaultProps} isLoading={true} />);
+
+    const switchElement = document.getElementById('test-checkbox') as HTMLButtonElement;
+    expect(switchElement).toBeDisabled();
+  });
+
+  it('shows loading spinner when isLoading is true', () => {
+    render(<SettingCheckbox {...defaultProps} isLoading={true} />);
+
+    const loader = document.querySelector('.animate-spin');
+    expect(loader).toBeInTheDocument();
+  });
+
+  it('does not show loading spinner when isLoading is false', () => {
+    render(<SettingCheckbox {...defaultProps} isLoading={false} />);
+
+    const loader = document.querySelector('.animate-spin');
+    expect(loader).not.toBeInTheDocument();
+  });
+});
+

--- a/components/common/SettingCheckbox.tsx
+++ b/components/common/SettingCheckbox.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Loader2 } from 'lucide-react';
+
+interface SettingCheckboxProps {
+  /** Unique identifier for the switch */
+  id: string;
+  /** Label text displayed above the switch */
+  label: string;
+  /** Optional description text displayed below the switch */
+  description?: string;
+  /** Current checked state */
+  checked: boolean;
+  /** Callback when switch state changes */
+  onCheckedChange: (checked: boolean) => void;
+  /** Whether the switch is in a loading state */
+  isLoading?: boolean;
+  /** Whether the switch is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Reusable switch component for settings pages.
+ *
+ * Follows consistent styling with Label above, switch control, and optional description below.
+ * Displays loading spinner when updating.
+ */
+export function SettingCheckbox({
+  id,
+  label,
+  description,
+  checked,
+  onCheckedChange,
+  isLoading = false,
+  disabled = false,
+}: SettingCheckboxProps) {
+  return (
+    <>
+      <Label htmlFor={id}>{label}</Label>
+      <div className="flex items-center gap-2">
+        <Switch
+          id={id}
+          checked={checked}
+          onCheckedChange={onCheckedChange}
+          disabled={disabled || isLoading}
+        />
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+      </div>
+      {description && (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      )}
+    </>
+  );
+}
+

--- a/components/features/settings/AutoLogAutoPayCheckbox.test.tsx
+++ b/components/features/settings/AutoLogAutoPayCheckbox.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AutoLogAutoPayCheckbox } from './AutoLogAutoPayCheckbox';
+import { updateAutoLogAutoPay } from '@/actions/settings';
+import { toast } from 'sonner';
+
+jest.mock('@/actions/settings', () => ({
+  updateAutoLogAutoPay: jest.fn(),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('AutoLogAutoPayCheckbox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with label and description', () => {
+    render(<AutoLogAutoPayCheckbox checked={true} />);
+
+    expect(screen.getByText('Automatically log automatic bills')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'If an automatic bill has an amount due set, Oar will automatically log it on the due date'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders switch as checked when checked prop is true', () => {
+    render(<AutoLogAutoPayCheckbox checked={true} />);
+
+    const switchElement = document.getElementById('autoLogAutoPay') as HTMLButtonElement;
+    expect(switchElement).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders switch as unchecked when checked prop is false', () => {
+    render(<AutoLogAutoPayCheckbox checked={false} />);
+
+    const switchElement = document.getElementById('autoLogAutoPay') as HTMLButtonElement;
+    expect(switchElement).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls updateAutoLogAutoPay and shows success toast when toggled to enabled', async () => {
+    const user = userEvent.setup();
+    (updateAutoLogAutoPay as jest.Mock).mockResolvedValue({ success: true });
+
+    render(<AutoLogAutoPayCheckbox checked={false} />);
+
+    const switchElement = document.getElementById('autoLogAutoPay') as HTMLButtonElement;
+    await user.click(switchElement);
+
+    await waitFor(() => {
+      expect(updateAutoLogAutoPay).toHaveBeenCalledWith({ enabled: true });
+      expect(toast.success).toHaveBeenCalledWith('Setting updated');
+    });
+  });
+
+  it('calls updateAutoLogAutoPay and shows success toast when toggled to disabled', async () => {
+    const user = userEvent.setup();
+    (updateAutoLogAutoPay as jest.Mock).mockResolvedValue({ success: true });
+
+    render(<AutoLogAutoPayCheckbox checked={true} />);
+
+    const switchElement = document.getElementById('autoLogAutoPay') as HTMLButtonElement;
+    await user.click(switchElement);
+
+    await waitFor(() => {
+      expect(updateAutoLogAutoPay).toHaveBeenCalledWith({ enabled: false });
+      expect(toast.success).toHaveBeenCalledWith('Setting updated');
+    });
+  });
+
+  it('shows error toast and reverts state when update fails', async () => {
+    const user = userEvent.setup();
+    (updateAutoLogAutoPay as jest.Mock).mockResolvedValue({
+      success: false,
+      error: 'Update failed',
+    });
+
+    render(<AutoLogAutoPayCheckbox checked={true} />);
+
+    const switchElement = document.getElementById('autoLogAutoPay') as HTMLButtonElement;
+    await user.click(switchElement);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Update failed');
+      expect(switchElement).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  it('shows loading spinner while updating', async () => {
+    const user = userEvent.setup();
+    let resolveUpdate: (value: { success: boolean }) => void;
+    const updatePromise = new Promise<{ success: boolean }>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    (updateAutoLogAutoPay as jest.Mock).mockReturnValue(updatePromise);
+
+    render(<AutoLogAutoPayCheckbox checked={false} />);
+
+    const switchElement = document.getElementById('autoLogAutoPay') as HTMLButtonElement;
+    await user.click(switchElement);
+
+    await waitFor(() => {
+      const loader = document.querySelector('.animate-spin');
+      expect(loader).toBeInTheDocument();
+    });
+
+    resolveUpdate!({ success: true });
+    await waitFor(() => {
+      expect(updateAutoLogAutoPay).toHaveBeenCalled();
+    });
+  });
+
+  it('disables switch while update is pending', async () => {
+    const user = userEvent.setup();
+    let resolveUpdate: (value: { success: boolean }) => void;
+    const updatePromise = new Promise<{ success: boolean }>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    (updateAutoLogAutoPay as jest.Mock).mockReturnValue(updatePromise);
+
+    render(<AutoLogAutoPayCheckbox checked={false} />);
+
+    const switchElement = document.getElementById('autoLogAutoPay') as HTMLButtonElement;
+    await user.click(switchElement);
+
+    await waitFor(() => {
+      expect(switchElement).toBeDisabled();
+    });
+
+    resolveUpdate!({ success: true });
+    await waitFor(() => {
+      expect(updateAutoLogAutoPay).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/components/features/settings/AutoLogAutoPayCheckbox.tsx
+++ b/components/features/settings/AutoLogAutoPayCheckbox.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import { updateAutoLogAutoPay } from '@/actions/settings';
+import { toast } from 'sonner';
+import { SettingCheckbox } from '@/components/common/SettingCheckbox';
+
+interface AutoLogAutoPayCheckboxProps {
+  checked: boolean;
+}
+
+export function AutoLogAutoPayCheckbox({ checked: initialChecked }: AutoLogAutoPayCheckboxProps) {
+  const [checked, setChecked] = useState(initialChecked);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleCheckedChange = async (newChecked: boolean) => {
+    setIsLoading(true);
+    setChecked(newChecked);
+
+    const result = await updateAutoLogAutoPay({ enabled: newChecked });
+
+    if (result.success) {
+      toast.success('Setting updated');
+    } else {
+      toast.error(result.error || 'Failed to update setting');
+      setChecked(!newChecked);
+    }
+
+    setIsLoading(false);
+  };
+
+  return (
+    <SettingCheckbox
+      id="autoLogAutoPay"
+      label="Automatically log automatic bills"
+      description="If an automatic bill has an amount due set, Oar will automatically log it on the due date"
+      checked={checked}
+      onCheckedChange={handleCheckedChange}
+      isLoading={isLoading}
+    />
+  );
+}
+

--- a/components/features/settings/SettingsSection.tsx
+++ b/components/features/settings/SettingsSection.tsx
@@ -6,6 +6,7 @@ import { ViewOptionsForm } from './ViewOptionsForm';
 import { BillEndActionDropdown } from './BillEndActionDropdown';
 import { WeekendAdjustmentDropdown } from './WeekendAdjustmentDropdown';
 import { updateDueSoonRange, updatePaidRecentlyRange, updateBillEndAction, updateWeekendAdjustment } from '@/actions/settings';
+import { AutoLogAutoPayCheckbox } from './AutoLogAutoPayCheckbox';
 import { FUTURE_RANGE_LABELS, PAST_RANGE_LABELS } from '@/lib/constants';
 import { SettingsService } from '@/lib/services/SettingsService';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
@@ -113,6 +114,13 @@ export async function SettingsSection({ section }: SettingsSectionProps) {
                       currentValue={setting.value as 'unchanged' | 'next_business_day' | 'previous_business_day'}
                       onUpdate={updateWeekendAdjustment}
                     />
+                  </FormItem>
+                );
+              }
+              if (setting.key === 'autoLogAutoPay') {
+                return (
+                  <FormItem key={setting.key}>
+                    <AutoLogAutoPayCheckbox checked={setting.value === 'true'} />
                   </FormItem>
                 );
               }

--- a/components/features/settings/ViewOptionsForm.test.tsx
+++ b/components/features/settings/ViewOptionsForm.test.tsx
@@ -58,7 +58,9 @@ describe('ViewOptionsForm', () => {
       expect(document.getElementById('currency-description')).toBeInTheDocument();
       expect(document.getElementById('locale-description')).toBeInTheDocument();
       expect(document.getElementById('weekstart-description')).toBeInTheDocument();
-      expect(document.getElementById('include-autopay-description')).toBeInTheDocument();
+      expect(
+        screen.getByText('Show automatic bills in Due Soon and Due This Month views')
+      ).toBeInTheDocument();
     });
 
     it('associates include auto pay label with switch via htmlFor', () => {

--- a/components/features/settings/ViewOptionsForm.tsx
+++ b/components/features/settings/ViewOptionsForm.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/select';
 import { FormItem } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
+import { SettingCheckbox } from '@/components/common/SettingCheckbox';
 import { updateViewOptions } from '@/actions/settings';
 import {
   CURRENCY_OPTIONS,
@@ -237,23 +237,17 @@ export function ViewOptionsForm({
       </FormItem>
 
       <FormItem>
-        <Label htmlFor="include-autopay-toggle">Include automatic bills in bills due soon</Label>
-        <div className="flex items-center gap-2">
-          <Switch
-            id="include-autopay-toggle"
-            checked={state.includeAutoPayInDueSoon}
-            onCheckedChange={(checked) =>
-              handleUpdate('includeAutoPayInDueSoon', String(checked))
-            }
-            disabled={isPending}
-          />
-          {isIncludeAutoPayInDueSoonUpdating && (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          )}
-        </div>
-        <p id="include-autopay-description" className="text-xs text-muted-foreground">
-          Show automatic bills in Due Soon and Due This Month views
-        </p>
+        <SettingCheckbox
+          id="include-autopay-toggle"
+          label="Include automatic bills in bills due soon"
+          description="Show automatic bills in Due Soon and Due This Month views"
+          checked={state.includeAutoPayInDueSoon}
+          onCheckedChange={(checked) =>
+            handleUpdate('includeAutoPayInDueSoon', String(checked))
+          }
+          isLoading={isIncludeAutoPayInDueSoonUpdating}
+          disabled={isPending}
+        />
       </FormItem>
     </div>
   );

--- a/docs/features/000-active-payer-philosophy.md
+++ b/docs/features/000-active-payer-philosophy.md
@@ -1,7 +1,7 @@
 # Active Payer Philosophy
 
 - **Status:** Draft
-- **Last Updated:** 2025-12-25
+- **Last Updated:** 2025-12-30
 
 ## Overview
 
@@ -67,7 +67,7 @@ Passive systems encourage you to set it and forget it. Active Payer systems enco
 
 ## Edge cases and constraints
 
-**Auto-pay bills:** Bills marked as auto-pay still require your verification. The system logs payments automatically, but you should check your bank statement to ensure the expected amount was charged. If amounts differ, you can edit the logged payment.
+**Auto-pay bills:** Bills marked as auto-pay still require your verification. When the "Automatically log automatic bills" setting is enabled, the system logs payments automatically, but you should check your bank statement to ensure the expected amount was charged. If amounts differ, you can edit the logged payment. You can also disable auto-logging to manually log each payment, giving you full control to verify amounts before recording them.
 
 **Historical payments:** When onboarding existing bills, you can log past payments without affecting the current billing cycle. The system detects historical payments and records them separately. This lets you build complete payment history while keeping current obligations accurate.
 

--- a/docs/features/002-auto-pay.md
+++ b/docs/features/002-auto-pay.md
@@ -115,7 +115,9 @@ If you need to correct a payment mistake, click any payment row to view its deta
 
 **Bill already paid.** For one-time bills marked as paid, the Log Payment button is disabled.
 
-**Auto-pay bills.** If you've marked a bill as auto-pay, Oar logs payments automatically when the due date arrives. AutoPay eligibility uses adjusted payment dates (not anchor dates) to determine when a bill becomes due. For example, a bill due Saturday January 15 with "Move to Previous Business Day" strategy becomes eligible on Friday January 14. When processed, the transaction records the adjusted date for audit accuracy, but the next due date advances using the anchor date to prevent drift. You'll still see these payments in the bill's history. See [Background Jobs](./006-background-jobs.md) and [Active Payer Signals](./010-active-payer-signals.md) for details.
+**Auto-pay bills.** If you've marked a bill as auto-pay, Oar can log payments automatically when the due date arrives. This behavior is controlled by the "Automatically log automatic bills" setting in Settings → Logging Settings. When enabled (the default), the background job processes auto-pay bills and creates payment records automatically. When disabled, you must manually log payments for auto-pay bills using the Log Payment dialog, giving you full control to verify amounts before recording them.
+
+AutoPay eligibility uses adjusted payment dates (not anchor dates) to determine when a bill becomes due. For example, a bill due Saturday January 15 with "Move to Previous Business Day" strategy becomes eligible on Friday January 14. When processed, the transaction records the adjusted date for audit accuracy, but the next due date advances using the anchor date to prevent drift. You'll still see these payments in the bill's history. See [Background Jobs](./006-background-jobs.md) and [Active Payer Signals](./010-active-payer-signals.md) for details.
 
 ## Verification
 

--- a/docs/features/006-background-jobs.md
+++ b/docs/features/006-background-jobs.md
@@ -1,7 +1,7 @@
 # Background Jobs
 
 - **Status:** Draft
-- **Last Updated:** 2025-12-27
+- **Last Updated:** 2025-12-30
 
 ## Overview
 
@@ -19,20 +19,24 @@ For details on how bill statuses work, see [Recurrence Engine](./001-recurrence-
 
 Runs at 00:05 UTC (five minutes after the status check).
 
-If you've marked a bill as "auto-pay," this job handles the bookkeeping when the due date arrives. It creates a payment record and advances the bill to its next due date.
+If you've marked a bill as "auto-pay," this job can handle the bookkeeping when the due date arrives. It creates a payment record and advances the bill to its next due date. This behavior is controlled by the "Automatically log automatic bills" setting in Settings → Logging Settings. When the setting is disabled, the job skips processing and you must log payments manually.
 
 ### What "auto-pay" means in Oar
 
-Marking a bill as auto-pay tells Oar that your bank handles payment automatically (direct debit, recurring card charge, etc.). Oar doesn't send money anywhere. It logs the payment in your history so you have a complete record, then advances the due date so your bill list stays current.
+Marking a bill as auto-pay tells Oar that your bank handles payment automatically (direct debit, recurring card charge, etc.). Oar doesn't send money anywhere. When auto-logging is enabled, it logs the payment in your history so you have a complete record, then advances the due date so your bill list stays current.
 
-This reduces manual work for bills you've already delegated to your bank. You made the conscious choice to set up auto-pay externally; Oar respects that decision by keeping your records in sync.
+This reduces manual work for bills you've already delegated to your bank. You made the conscious choice to set up auto-pay externally; Oar respects that decision by keeping your records in sync. However, if you prefer to verify each payment amount before logging (especially important for variable bills where estimates may differ from actual charges), you can disable auto-logging and log payments manually.
 
 ### When auto-pay bills get processed
 
-A bill is processed when all these conditions are true:
+The job only processes bills when the "Automatically log automatic bills" setting is enabled. A bill is processed when all these conditions are true:
+- The auto-log setting is enabled
 - You marked it as auto-pay
 - The due date has arrived (today or earlier)
 - It hasn't already been paid
+- The amount due is greater than zero
+
+The amount due check ensures bills that are already fully paid in the current cycle (from partial payments) or variable bills after cycle advance (where amount due resets to zero) are not processed until the next cycle when an amount is due.
 
 Once processed:
 - A payment record appears in the bill's history with the note "Logged by Oar"

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -92,6 +92,7 @@ export const DEFAULT_SETTINGS_VALUES = [
   { key: 'includeAutoPayInDueSoon', value: 'true', sectionSlug: 'view-options' },
   { key: 'theme', value: 'system', sectionSlug: 'view-options' },
   { key: 'notifications_enabled', value: 'true', sectionSlug: 'notification-settings' },
+  { key: 'autoLogAutoPay', value: 'true', sectionSlug: 'logging-settings' },
 ] as const;
 
 /** Default weekend adjustment strategy when no global setting is configured. */

--- a/lib/services/AutoPayService.test.ts
+++ b/lib/services/AutoPayService.test.ts
@@ -20,6 +20,7 @@ jest.mock('./RecurrenceService', () => ({
 jest.mock('./SettingsService', () => ({
   SettingsService: {
     getWeekendAdjustment: jest.fn(),
+    getAutoLogAutoPay: jest.fn(),
   },
 }));
 
@@ -74,36 +75,69 @@ describe('AutoPayService', () => {
   };
 
   describe('processAutoPay', () => {
-    it('processes eligible auto-pay bill', async () => {
-      // Setup: Bill with isAutoPay=true, status='pending', dueDate=today
+    beforeEach(() => {
+      (SettingsService.getAutoLogAutoPay as jest.Mock).mockResolvedValue(true);
+    });
+
+    it('returns early when auto-log is disabled', async () => {
+      (SettingsService.getAutoLogAutoPay as jest.Mock).mockResolvedValue(false);
+
+      const result = await AutoPayService.processAutoPay();
+
+      expect(result).toEqual({
+        processed: 0,
+        failed: 0,
+        failedIds: [],
+      });
+      expect(SettingsService.getAutoLogAutoPay).toHaveBeenCalled();
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('processes eligible auto-pay bill when auto-log is enabled', async () => {
       const mockBill = createMockBill({
         id: 'bill-monthly',
         dueDate: new Date(),
         frequency: 'monthly',
+        amountDue: 9999,
       });
       mockSelectBills([mockBill]);
 
-      // Mock RecurrenceService to return next month
       const nextMonth = new Date();
       nextMonth.setMonth(nextMonth.getMonth() + 1);
       (RecurrenceService.calculateNextDueDate as jest.Mock).mockReturnValue(nextMonth);
       (RecurrenceService.deriveStatus as jest.Mock).mockReturnValue('pending');
+      (SettingsService.getWeekendAdjustment as jest.Mock).mockResolvedValue('unchanged');
+      (DateAdjustmentService.getEffectiveStrategy as jest.Mock).mockReturnValue('unchanged');
+      (DateAdjustmentService.adjustPaymentDate as jest.Mock).mockImplementation((date) => date);
 
-      // Action
       const result = await AutoPayService.processAutoPay();
 
-      // Assert
       expect(result).toEqual({
         processed: 1,
         failed: 0,
         failedIds: [],
       });
+      expect(SettingsService.getAutoLogAutoPay).toHaveBeenCalled();
       expect(db.transaction).toHaveBeenCalled();
       expect(RecurrenceService.calculateNextDueDate).toHaveBeenCalledWith(
         mockBill.dueDate,
         'monthly',
         null
       );
+    });
+
+    it('skips bills with amountDue = 0', async () => {
+      mockSelectBills([]);
+
+      const result = await AutoPayService.processAutoPay();
+
+      expect(result).toEqual({
+        processed: 0,
+        failed: 0,
+        failedIds: [],
+      });
+      expect(db.transaction).not.toHaveBeenCalled();
     });
 
     it('skips non-auto-pay bills', async () => {

--- a/lib/services/AutoPayService.ts
+++ b/lib/services/AutoPayService.ts
@@ -2,7 +2,7 @@ import { db, bills, transactions } from '@/db';
 import { RecurrenceService } from '@/lib/services/RecurrenceService';
 import { SettingsService } from '@/lib/services/SettingsService';
 import { DateAdjustmentService } from '@/lib/services/DateAdjustmentService';
-import { eq, and, lte, ne } from 'drizzle-orm';
+import { eq, and, lte, ne, gt } from 'drizzle-orm';
 import { endOfDay, addDays } from 'date-fns';
 import { getLogger } from '@/lib/logger';
 
@@ -52,6 +52,13 @@ export const AutoPayService = {
   async processAutoPay(): Promise<AutoPayResult> {
     const today = endOfDay(new Date());
 
+    // Check if auto-log is enabled
+    const autoLogAutoPay = await SettingsService.getAutoLogAutoPay();
+    if (!autoLogAutoPay) {
+      logger.info('Auto-log disabled, skipping auto-pay processing');
+      return { processed: 0, failed: 0, failedIds: [] };
+    }
+
     // Fetch global weekend adjustment setting once per batch
     const globalStrategy = await SettingsService.getWeekendAdjustment();
 
@@ -69,7 +76,8 @@ export const AutoPayService = {
           eq(bills.isAutoPay, true),
           ne(bills.status, 'paid'),
           lte(bills.dueDate, addDays(today, 2)),
-          eq(bills.isArchived, false)
+          eq(bills.isArchived, false),
+          gt(bills.amountDue, 0)
         )
       );
 

--- a/lib/services/SettingsService.test.ts
+++ b/lib/services/SettingsService.test.ts
@@ -95,6 +95,7 @@ describe('SettingsService', () => {
           { key: 'locale', value: 'de-DE' },
           { key: 'weekStart', value: '1' },
           { key: 'includeAutoPayInDueSoon', value: 'false' },
+          { key: 'autoLogAutoPay', value: 'false' },
         ])
       );
 
@@ -104,6 +105,7 @@ describe('SettingsService', () => {
       expect(result.locale).toBe('de-DE');
       expect(result.weekStart).toBe(1);
       expect(result.includeAutoPayInDueSoon).toBe(false);
+      expect(result.autoLogAutoPay).toBe(false);
     });
 
     it('uses defaults when settings are missing', async () => {
@@ -115,6 +117,7 @@ describe('SettingsService', () => {
       expect(result.locale).toBe(DEFAULT_LOCALE);
       expect(result.weekStart).toBe(0);
       expect(result.includeAutoPayInDueSoon).toBe(true);
+      expect(result.autoLogAutoPay).toBe(true);
     });
 
     it('parses weekStart as number', async () => {
@@ -387,13 +390,14 @@ describe('SettingsService', () => {
 
       await SettingsService.initialize();
 
-      expect(db.insert).toHaveBeenCalledTimes(4);
+      expect(db.insert).toHaveBeenCalledTimes(5);
       expect(db.insert).toHaveBeenCalledWith(settings);
     });
 
     it('skips existing settings', async () => {
       (db.select as jest.Mock)
         .mockReturnValueOnce(createSelectBuilderSync([{ key: 'currency', value: 'EUR' }]))
+        .mockReturnValueOnce(createSelectBuilderSync([]))
         .mockReturnValueOnce(createSelectBuilderSync([]))
         .mockReturnValueOnce(createSelectBuilderSync([]))
         .mockReturnValueOnce(createSelectBuilderSync([]));
@@ -407,7 +411,7 @@ describe('SettingsService', () => {
 
       await SettingsService.initialize();
 
-      expect(db.insert).toHaveBeenCalledTimes(3);
+      expect(db.insert).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -911,6 +915,51 @@ describe('SettingsService', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         { invalidValue: 'invalid' },
         'Invalid includeAutoPayInDueSoon value, defaulting to true'
+      );
+    });
+  });
+
+  describe('getAutoLogAutoPay', () => {
+    it('returns true when stored value is "true"', async () => {
+      (db.select as jest.Mock).mockReturnValue(
+        createSelectBuilderSync([{ value: 'true' }])
+      );
+
+      const result = await SettingsService.getAutoLogAutoPay();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when stored value is "false"', async () => {
+      (db.select as jest.Mock).mockReturnValue(
+        createSelectBuilderSync([{ value: 'false' }])
+      );
+
+      const result = await SettingsService.getAutoLogAutoPay();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns default (true) when setting missing', async () => {
+      (db.select as jest.Mock).mockReturnValue(createSelectBuilderSync([]));
+
+      const result = await SettingsService.getAutoLogAutoPay();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns default (true) when stored value is invalid', async () => {
+      mockLogger.error.mockClear();
+      (db.select as jest.Mock).mockReturnValue(
+        createSelectBuilderSync([{ value: 'invalid' }])
+      );
+
+      const result = await SettingsService.getAutoLogAutoPay();
+
+      expect(result).toBe(true);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        { invalidValue: 'invalid' },
+        'Invalid autoLogAutoPay value, defaulting to true'
       );
     });
   });

--- a/lib/services/SettingsService.ts
+++ b/lib/services/SettingsService.ts
@@ -61,6 +61,8 @@ export interface UserSettings {
   weekStart: WeekStartDay;
   /** Whether to include automatic bills in Due Soon and Due This Month views. */
   includeAutoPayInDueSoon: boolean;
+  /** Whether to automatically log payments for auto-pay bills when due date arrives. */
+  autoLogAutoPay: boolean;
 }
 
 const DEFAULT_SETTINGS: UserSettings = {
@@ -68,6 +70,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   locale: DEFAULT_LOCALE,
   weekStart: 0,
   includeAutoPayInDueSoon: true,
+  autoLogAutoPay: true,
 };
 
 /**
@@ -104,11 +107,20 @@ export const SettingsService = {
           ? false
           : DEFAULT_SETTINGS.includeAutoPayInDueSoon;
 
+    const autoLogAutoPayValue = settingsMap['autoLogAutoPay'];
+    const autoLogAutoPay =
+      autoLogAutoPayValue === 'true'
+        ? true
+        : autoLogAutoPayValue === 'false'
+          ? false
+          : DEFAULT_SETTINGS.autoLogAutoPay;
+
     return {
       currency: settingsMap['currency'] ?? DEFAULT_SETTINGS.currency,
       locale: settingsMap['locale'] ?? DEFAULT_SETTINGS.locale,
       weekStart,
       includeAutoPayInDueSoon,
+      autoLogAutoPay,
     };
   },
 
@@ -574,6 +586,40 @@ export const SettingsService = {
         invalidValue: row.value,
       },
       'Invalid includeAutoPayInDueSoon value, defaulting to true'
+    );
+    return true;
+  },
+
+  /**
+   * Retrieves the "automatically log auto-pay bills" setting.
+   *
+   * @returns {Promise<boolean>} True if auto-pay bills should be automatically logged, false otherwise.
+   * Defaults to true if not set.
+   */
+  async getAutoLogAutoPay(): Promise<boolean> {
+    const [row] = await db
+      .select()
+      .from(settings)
+      .where(eq(settings.key, 'autoLogAutoPay'))
+      .limit(1);
+
+    if (!row) {
+      return true;
+    }
+
+    if (row.value === 'true') {
+      return true;
+    }
+
+    if (row.value === 'false') {
+      return false;
+    }
+
+    logger.error(
+      {
+        invalidValue: row.value,
+      },
+      'Invalid autoLogAutoPay value, defaulting to true'
     );
     return true;
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Feat

**Intent:** Introduce a user-configurable setting to control automatic logging of auto-pay bills. When enabled (default), eligible bills are automatically logged; when disabled, users must manually log each payment, allowing full control over verification before recording.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `lib/services/SettingsService.ts` to understand the new `autoLogAutoPay` boolean setting and the `getAutoLogAutoPay()` method that reads the setting from storage with a default of `true`. Then review `lib/services/AutoPayService.ts` to see how the setting gates the bill processing logic with an early return when disabled. Finally, examine the UI layer: `components/common/SettingCheckbox.tsx` (reusable checkbox component) and `components/features/settings/AutoLogAutoPayCheckbox.tsx` (feature-specific implementation that calls `actions/settings.ts`'s `updateAutoLogAutoPay` action).

#### Sensitive Areas

- `lib/services/AutoPayService.ts`: Core business logic - the `processAutoPay` method now guards processing with `getAutoLogAutoPay()` check and filters bills by `amountDue > 0` to prevent processing fully-paid bills
- `lib/services/SettingsService.ts`: Setting persistence and defaults - the `getAutoLogAutoPay()` method handles invalid values by logging an error and defaulting to `true`
- `actions/settings.ts`: Contains a duplicate export of `updateAutoLogAutoPay` function and its validation schema that requires review to remove duplication

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes - the setting defaults to `true`, maintaining existing auto-logging behavior
- **Migrations/State:** No migrations or state changes - the setting is added to `DEFAULT_SETTINGS_VALUES` with default value `'true'` in `lib/constants.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->