### PR TITLE
Fix AutoPay Timezone Eligibility Bug

### DIFF
--- a/lib/services/AutoPayService.test.ts
+++ b/lib/services/AutoPayService.test.ts
@@ -694,6 +694,86 @@ describe('AutoPayService', () => {
 
       jest.useRealTimers();
     });
+
+    describe('timezone-agnostic eligibility (regression: premature processing bug)', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+        (SettingsService.getWeekendAdjustment as jest.Mock).mockResolvedValue('unchanged');
+        (DateAdjustmentService.getEffectiveStrategy as jest.Mock).mockReturnValue('unchanged');
+        (DateAdjustmentService.adjustPaymentDate as jest.Mock).mockImplementation((date) => date);
+        (RecurrenceService.calculateNextDueDate as jest.Mock).mockReturnValue(new Date('2026-02-02T23:00:00.000Z'));
+        (RecurrenceService.deriveStatus as jest.Mock).mockReturnValue('pending');
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it.each([
+        {
+          timezone: 'Poland (UTC+1)',
+          dueDateUTC: '2026-01-01T23:00:00.000Z',
+          cronTimeUTC: '2026-01-01T00:05:00.000Z',
+          shouldProcess: false,
+          description: 'Jan 2 00:00 Poland at Jan 1 00:05 UTC',
+        },
+        {
+          timezone: 'Poland (UTC+1)',
+          dueDateUTC: '2026-01-01T23:00:00.000Z',
+          cronTimeUTC: '2026-01-02T00:05:00.000Z',
+          shouldProcess: true,
+          description: 'Jan 2 00:00 Poland at Jan 2 00:05 UTC',
+        },
+        {
+          timezone: 'Japan (UTC+9)',
+          dueDateUTC: '2026-01-01T15:00:00.000Z',
+          cronTimeUTC: '2026-01-01T00:05:00.000Z',
+          shouldProcess: false,
+          description: 'Jan 2 00:00 Japan at Jan 1 00:05 UTC',
+        },
+        {
+          timezone: 'Japan (UTC+9)',
+          dueDateUTC: '2026-01-01T15:00:00.000Z',
+          cronTimeUTC: '2026-01-01T16:00:00.000Z',
+          shouldProcess: true,
+          description: 'Jan 2 00:00 Japan at Jan 1 16:00 UTC',
+        },
+        {
+          timezone: 'New York (UTC-5)',
+          dueDateUTC: '2026-01-02T05:00:00.000Z',
+          cronTimeUTC: '2026-01-02T00:05:00.000Z',
+          shouldProcess: false,
+          description: 'Jan 2 00:00 New York at Jan 2 00:05 UTC',
+        },
+        {
+          timezone: 'New York (UTC-5)',
+          dueDateUTC: '2026-01-02T05:00:00.000Z',
+          cronTimeUTC: '2026-01-02T06:00:00.000Z',
+          shouldProcess: true,
+          description: 'Jan 2 00:00 New York at Jan 2 06:00 UTC',
+        },
+      ])(
+        '$timezone: $description → $shouldProcess',
+        async ({ dueDateUTC, cronTimeUTC, shouldProcess }) => {
+          jest.setSystemTime(new Date(cronTimeUTC));
+
+          const mockBill = createMockBill({
+            id: 'bill-tz-test',
+            dueDate: new Date(dueDateUTC),
+          });
+          mockSelectBills([mockBill]);
+
+          const result = await AutoPayService.processAutoPay();
+
+          if (shouldProcess) {
+            expect(result.processed).toBe(1);
+            expect(db.transaction).toHaveBeenCalled();
+          } else {
+            expect(result.processed).toBe(0);
+            expect(db.transaction).not.toHaveBeenCalled();
+          }
+        }
+      );
+    });
   });
 });
-

--- a/lib/services/AutoPayService.ts
+++ b/lib/services/AutoPayService.ts
@@ -50,7 +50,10 @@ export const AutoPayService = {
    * @returns Summary of processing results
    */
   async processAutoPay(): Promise<AutoPayResult> {
+    // Use endOfDay for broad candidate query (catches weekend adjustments)
     const today = endOfDay(new Date());
+    // Use current moment for eligibility check (timezone-agnostic)
+    const now = new Date();
 
     // Check if auto-log is enabled
     const autoLogAutoPay = await SettingsService.getAutoLogAutoPay();
@@ -99,9 +102,15 @@ export const AutoPayService = {
           effectiveStrategy
         );
 
-        // Compare today against adjusted date (not anchor date) for eligibility
-        if (adjustedDueDate > today) {
+        // Compare current moment against adjusted date (not anchor date) for eligibility
+        // The due date timestamp encodes when the date starts in user's timezone
+        // We only process after that moment has passed (timezone-agnostic)
+        if (adjustedDueDate > now) {
           // Adjusted date hasn't arrived yet, skip this bill
+          logger.debug(
+            { billId: bill.id, adjustedDueDate: adjustedDueDate.toISOString(), now: now.toISOString() },
+            'Skipping bill: due date not yet reached'
+          );
           continue;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 🎯 Scope & Context

**Type:** Fix

**Intent:** Fix a premature processing bug in AutoPayService where bills were being incorrectly processed before their due dates arrived in certain timezones. The fix introduces a timezone-agnostic eligibility check by comparing the adjusted due date against the current moment instead of the end-of-day anchor date.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `lib/services/AutoPayService.ts` to understand the core fix: the eligibility gate now uses the current moment (`now`) instead of the end-of-day timestamp (`today`) when determining whether an adjusted due date has arrived. This ensures bills are not processed prematurely regardless of timezone. Then review `lib/services/AutoPayService.test.ts` to understand the regression test coverage across multiple timezones (Poland UTC+1, Japan UTC+9, New York UTC-5) that validates the fix prevents premature processing.

#### Sensitive Areas

- `lib/services/AutoPayService.ts`: Timezone-aware eligibility gate logic that determines when bills become eligible for processing; the timing comparison logic is critical to preventing premature processing
- `lib/services/AutoPayService.test.ts`: Regression test parameterization covering multiple timezone scenarios with specific due date and cron time combinations to validate timezone-aware behavior

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->