### PR TITLE
Increase test coverage for TimezoneProvider

### DIFF
--- a/components/common/TimezoneProvider.test.tsx
+++ b/components/common/TimezoneProvider.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
+import { TIMEZONE_COOKIE_NAME } from '@/lib/constants';
 import { TimezoneProvider } from './TimezoneProvider';
 
 describe('TimezoneProvider', () => {
-  const COOKIE_NAME = 'oar-tz-offset';
   let cookieGetter: jest.Mock;
   let cookieSetter: jest.Mock;
   let originalCookieDescriptor: PropertyDescriptor | undefined;
@@ -46,7 +46,7 @@ describe('TimezoneProvider', () => {
 
     expect(cookieSetter).toHaveBeenCalledTimes(1);
     expect(cookieSetter).toHaveBeenCalledWith(
-      `${COOKIE_NAME}=1; path=/; max-age=${oneYearInSeconds}; SameSite=Lax`
+      `${TIMEZONE_COOKIE_NAME}=1; path=/; max-age=${oneYearInSeconds}; SameSite=Lax`
     );
   });
 
@@ -62,13 +62,13 @@ describe('TimezoneProvider', () => {
     render(<TimezoneProvider />);
 
     expect(cookieSetter).toHaveBeenCalledWith(
-      expect.stringContaining(`${COOKIE_NAME}=${expectedHours}`)
+      expect.stringContaining(`${TIMEZONE_COOKIE_NAME}=${expectedHours}`)
     );
   });
 
   it('does not update cookie if value is already correct', () => {
     jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-60);
-    cookieGetter.mockReturnValue(`${COOKIE_NAME}=1`);
+    cookieGetter.mockReturnValue(`${TIMEZONE_COOKIE_NAME}=1`);
 
     render(<TimezoneProvider />);
 
@@ -77,12 +77,12 @@ describe('TimezoneProvider', () => {
 
   it('updates cookie if existing value differs', () => {
     jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-60);
-    cookieGetter.mockReturnValue(`${COOKIE_NAME}=-5`);
+    cookieGetter.mockReturnValue(`${TIMEZONE_COOKIE_NAME}=-5`);
 
     render(<TimezoneProvider />);
 
     expect(cookieSetter).toHaveBeenCalledWith(
-      expect.stringContaining(`${COOKIE_NAME}=1`)
+      expect.stringContaining(`${TIMEZONE_COOKIE_NAME}=1`)
     );
   });
 
@@ -98,7 +98,7 @@ describe('TimezoneProvider', () => {
 
   it('handles cookie with multiple entries', () => {
     jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-60);
-    cookieGetter.mockReturnValue(`other-cookie=value; ${COOKIE_NAME}=1; another=test`);
+    cookieGetter.mockReturnValue(`other-cookie=value; ${TIMEZONE_COOKIE_NAME}=1; another=test`);
 
     render(<TimezoneProvider />);
 
@@ -107,7 +107,7 @@ describe('TimezoneProvider', () => {
 
   it('handles fractional offsets with tolerance', () => {
     jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
-    cookieGetter.mockReturnValue(`${COOKIE_NAME}=5.5`);
+    cookieGetter.mockReturnValue(`${TIMEZONE_COOKIE_NAME}=5.5`);
 
     render(<TimezoneProvider />);
 
@@ -116,23 +116,23 @@ describe('TimezoneProvider', () => {
 
   it('updates cookie when value differs slightly beyond tolerance', () => {
     jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
-    cookieGetter.mockReturnValue(`${COOKIE_NAME}=5.4`);
+    cookieGetter.mockReturnValue(`${TIMEZONE_COOKIE_NAME}=5.4`);
 
     render(<TimezoneProvider />);
 
     expect(cookieSetter).toHaveBeenCalledWith(
-      expect.stringContaining(`${COOKIE_NAME}=5.5`)
+      expect.stringContaining(`${TIMEZONE_COOKIE_NAME}=5.5`)
     );
   });
 
   it('handles invalid cookie value gracefully', () => {
     jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-60);
-    cookieGetter.mockReturnValue(`${COOKIE_NAME}=invalid`);
+    cookieGetter.mockReturnValue(`${TIMEZONE_COOKIE_NAME}=invalid`);
 
     render(<TimezoneProvider />);
 
     expect(cookieSetter).toHaveBeenCalledWith(
-      expect.stringContaining(`${COOKIE_NAME}=1`)
+      expect.stringContaining(`${TIMEZONE_COOKIE_NAME}=1`)
     );
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### 🎯 Scope & Context
**Type:** Chore  
**Intent:** Add comprehensive unit tests for `TimezoneProvider` to validate cookie read/write behavior, timezone offset → hour conversion, fractional-offset tolerance, single-run guards, multi-cookie parsing, and edge-case handling to ensure reliable server-side timezone detection.

### 🧭 Reviewer Guide
**Complexity:** Low

#### Entry Point
Start with `components/common/TimezoneProvider.test.tsx` — this file contains the full test suite (12 tests) covering rendering, cookie setting format (path, SameSite, max-age ≈ 1 year), conversion of minute offsets to hour values (including fractional offsets), tolerance checks, no-op when cookie matches, update when differing, single-execution behavior, multiple-cookie parsing, and invalid-value handling. Then review `components/common/TimezoneProvider.tsx` to confirm the implementation under test: useEffect with hasRun guard, calculation of `offsetHours = -(new Date().getTimezoneOffset() / 60)`, existing cookie parsing, tolerance threshold (Math.abs < 0.01), and cookie-writing string composition.

#### Sensitive Areas
- `components/common/TimezoneProvider.test.tsx` - cookie mocking (`document.cookie` getter/setter), lifecycle of mocks (`beforeEach`/`afterAll`), and Jest spies on `Date.prototype.getTimezoneOffset`.
- `components/common/TimezoneProvider.tsx` - offset sign/scale conversion, tolerance value (0.01) for fractional offsets, cookie parsing logic (splitting `document.cookie`), and the exact cookie attributes (`path=/; max-age=365*24*60*60; SameSite=Lax`).

### ⚠️ Risk Assessment
- **Breaking Changes:** No breaking changes - tests only, no production code modifications.  
- **Migrations/State:** No migrations or state changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->