### PR TITLE
chore(dev): configure PAGER globally and simplify docs

### DIFF
--- a/.github/skills/pull-request/SKILL.md
+++ b/.github/skills/pull-request/SKILL.md
@@ -202,10 +202,8 @@ After creating, verify and report:
 
 ```bash
 # Get PR URL
-PAGER=cat gh pr view
+gh pr view
 ```
-
-**IMPORTANT:** You have to use the `PAGER=cat` environment variable to avoid interactive pager blocking output.
 
 Report to the user:
 

--- a/oar.code-workspace
+++ b/oar.code-workspace
@@ -1,18 +1,29 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {
-		"editor.rulers": [
-			100
-		]
-	},
-	"extensions": {
-		"recommendations": [
-			"mkhl.direnv",
-			"elagil.pre-commit-helper"
-		]
-	}
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "editor.rulers": [
+      100
+    ],
+		// Setting PAGER to "cat" to avoid interactive pager blocking output in terminal
+		// when agent runs commands like `gh pr view`.
+    "terminal.integrated.env.linux": {
+      "PAGER": "cat"
+    },
+    "terminal.integrated.env.osx": {
+      "PAGER": "cat"
+    },
+    "terminal.integrated.env.windows": {
+      "PAGER": "cat"
+    }
+  },
+  "extensions": {
+    "recommendations": [
+      "mkhl.direnv",
+      "elagil.pre-commit-helper"
+    ]
+  }
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Configure `PAGER=cat` globally in workspace settings and remove explicit usage from documentation.

### 📝 Context
The user identified a way to avoid polluting prompt instructions by setting the PAGER environment variable directly in the VS Code workspace settings. This eliminates the need to prepend `PAGER=cat` to every `gh` command in the documentation.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Changes
- **`oar.code-workspace`**: Added `terminal.integrated.env.*` settings to set `PAGER` to `cat`.
- **`SKILL.md`**: Removed `PAGER=cat` instruction from the PR skill documentation.

### ⚠️ Risk Assessment

- **Breaking Changes:** No
- **Migrations/State:** No