### PR TITLE
fix(ci): resolve untrusted checkout TOCTOU vulnerability in PR workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -59,15 +59,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Prepare inputs
         id: prepare_inputs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Checkout the PR head ref for accurate diff
-          gh pr checkout "$PR_NUMBER" --detach
-
           # Get PR diff (limit to 2000 lines to stay within token limits)
           gh pr diff "$PR_NUMBER" --patch | head -n 2000 > /tmp/pr_diff.txt
 


### PR DESCRIPTION
Potential fix for [https://github.com/sergeyklay/oar/security/code-scanning/6](https://github.com/sergeyklay/oar/security/code-scanning/6)

In general, to fix this class of problem you must ensure that when a privileged workflow runs in response to potentially untrusted events, it never checks out or executes mutable branch references from the untrusted PR; instead, it should operate on an immutable commit SHA (`head.sha`), which cannot change between approval/gating and execution.

For this specific workflow, the easiest fix without changing functionality is:

1. Avoid `actions/checkout` checking out the default branch and then re-checking out the PR via `gh pr checkout`. Instead, directly check out the PR’s current commit by SHA using `actions/checkout`’s `ref` input.
2. Use `github.event.pull_request.head.sha` as the checkout reference. This is immutable for the event payload and prevents TOCTOU between security checks and code usage.
3. Because we only rely on `gh pr diff`, `gh pr view`, and reading `.github/skills/pr-naming/SKILL.md`, switching from `gh pr checkout` to `actions/checkout` with `ref: ${{ github.event.pull_request.head.sha }}` preserves behavior while removing the untrusted mutable ref.

Concretely:

- In `.github/workflows/pr-title.yml`, change the “Checkout code” step to use `ref: ${{ github.event.pull_request.head.sha }}`.
- In the “Prepare inputs” step, remove the `gh pr checkout "$PR_NUMBER" --detach` line, since the correct commit is already checked out. The remaining `gh` commands operate logically on the PR object and do not depend on a branch checkout.

No additional imports or actions are needed; we reuse `actions/checkout@v6` and the existing `gh` CLI usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
